### PR TITLE
Escape the \ in settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ your computer and set the appropriate path in your VSCode `settings.json`:
 
 ```
 {
-    "git.path": "C:\CHANGE\TO\PATH\TO\wslgit.exe"
+    "git.path": "C:\\CHANGE\\TO\\PATH\\TO\\wslgit.exe"
 }
 ```
 


### PR DESCRIPTION
If you don't escape the **\** in the path, you'll have an error like this
```
file: 'file:///c%3A/Users/<USERNAME>/AppData/Roaming/Code/User/settings.json'
severity: 'Error'
message: 'Invalid escape character in string' at: '5,17'
source: ''
```