### PR TITLE
Non interactive and advanced .bashrc startup file loading

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,6 @@ fn translate_path_to_win(line: &str) -> String {
     String::from(line)
 }
 
-/*
 fn shell_escape(arg: String) -> String {
     // ToDo: This really only handles arguments with spaces.
     // More complete shell escaping is required for the general case.
@@ -60,14 +59,39 @@ fn shell_escape(arg: String) -> String {
     }
     arg
 }
-*/
 
 fn main() {
+    let mut cmd_args = Vec::new();
     let mut git_args: Vec<String> = vec![String::from("git")];
-    git_args.extend(env::args().skip(1)
-        //.map(shell_escape)
+    let git_cmd: String;
+
+    // check for advanced usage indicated by BASH_ENV and WSLENV=BASH_ENV
+    let mut interactive_shell = true;
+    if env::var("BASH_ENV").is_ok() {
+        let wslenv = env::var("WSLENV");
+        if wslenv.is_ok() && wslenv.unwrap().split(':').position(|r| r.eq_ignore_ascii_case("BASH_ENV")).is_some() {
+            interactive_shell = false;
+        }
+    }
+
+    // process git command arguments
+    if interactive_shell {
+        git_args.extend(env::args().skip(1)
+            .map(translate_path_to_unix)
+            .map(shell_escape));
+        git_cmd = git_args.join(" ");
+        cmd_args.push("bash".to_string());
+        cmd_args.push("-ic".to_string());
+        cmd_args.push(git_cmd.clone());
+    }
+    else {
+        git_args.extend(env::args().skip(1)
         .map(translate_path_to_unix));
-    let git_cmd = git_args.join(" ");
+        git_cmd = git_args.join(" ");
+        cmd_args.clone_from(&git_args);
+    }
+
+    // setup stdin/stdout
     let stdin_mode = if git_cmd.ends_with("--version") {
         // For some reason, the git subprocess seems to hang, waiting for 
         // input, when VS Code 1.17.2 tries to detect if `git --version` works
@@ -81,9 +105,10 @@ fn main() {
     } else {
         Stdio::inherit()
     };
+
+    // launch git inside WSL
     let git_proc = Command::new("wsl")
-        .env("BASH_ENV", "~/.bashrc")
-        .args(&git_args)
+        .args(&cmd_args)
         .stdin(stdin_mode)
         .stdout(Stdio::piped())
         .spawn()
@@ -92,6 +117,7 @@ fn main() {
         .wait_with_output()
         .expect(&format!("Failed to wait for git call '{}'", &git_cmd));
     let output_str = String::from_utf8_lossy(&output.stdout);
+
     // add git commands that must skip translate_path_to_win
     // e.g. = &["show", "status, "rev-parse", "for-each-ref"];
     const NO_TRANSLATE: &'static [&'static str] = &["show"];
@@ -103,6 +129,8 @@ fn main() {
     else {
         print!("{}", output_str);
     }
+
+    // forward any exit code
     if let Some(exit_code) = output.status.code() {
         std::process::exit(exit_code);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn main() {
         Stdio::inherit()
     };
     let git_proc = Command::new("bash")
-        .arg("-i")
+        .env("BASH_ENV", "~/.bashrc")
         .arg("-c")
         .arg(&git_cmd)
         .stdin(stdin_mode)

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ fn translate_path_to_win(line: &str) -> String {
     String::from(line)
 }
 
+/*
 fn shell_escape(arg: String) -> String {
     // ToDo: This really only handles arguments with spaces.
     // More complete shell escaping is required for the general case.
@@ -59,12 +60,13 @@ fn shell_escape(arg: String) -> String {
     }
     arg
 }
+*/
 
 fn main() {
     let mut git_args: Vec<String> = vec![String::from("git")];
     git_args.extend(env::args().skip(1)
-        .map(translate_path_to_unix)
-        .map(shell_escape));
+        //.map(shell_escape)
+        .map(translate_path_to_unix));
     let git_cmd = git_args.join(" ");
     let stdin_mode = if git_cmd.ends_with("--version") {
         // For some reason, the git subprocess seems to hang, waiting for 
@@ -79,10 +81,9 @@ fn main() {
     } else {
         Stdio::inherit()
     };
-    let git_proc = Command::new("bash")
+    let git_proc = Command::new("wsl")
         .env("BASH_ENV", "~/.bashrc")
-        .arg("-c")
-        .arg(&git_cmd)
+        .args(&git_args)
         .stdin(stdin_mode)
         .stdout(Stdio::piped())
         .spawn()


### PR DESCRIPTION
This adds a feature to enable more flexible management of which startup files run with WSLgit as discussed in issue https://github.com/andy-5/wslgit/issues/16

### Windows 10 builds less than 17063
No change.
Launches git in interactive, non-login bash shell.

### Windows 10 builds 17063 and later
Optional change.
Launches git in interactive _or_ non-interactive, non-login bash shell.

* When [Windows environment variable](https://blogs.msdn.microsoft.com/commandline/2017/12/22/share-environment-vars-between-wsl-and-windows/) `BASH_ENV` is set *and* variable `WSLENV` contains "BASH_ENV", then WSLgit is launched into WSL bash with a non-interactive non-login shell. e.g.  
`BASH_ENV=~/.bashrc`  
`WSLENV=VAR1:BASH_ENV:VAR3:VAR4`
* WSL's Bash will read the `BASH_ENV` variable and load the given file. In that file, you can detect it being interactive or non-interactive and manage things you want to do in each case. For example, you may want to always set variables for GPG, SSH, etc. However, for non-interactive shells, you may want to skip slow actions.

Launching WSLgit as non-interactive and skipping slow actions in .bashrc can significantly speed the responsiveness of WSLgit. For example, it changed my response time from several seconds down to microseconds.

This PR uses `wsl.exe` to launch into WSL instead of the deprecated `bash.exe`.

### Example .bashrc

```bash

# this code runs for all cases
GPGKEY="abcd1234"

# If not running interactively, don't do anything
case $- in
    *i*) ;;
      *) return;;
esac

# this code runs only in interactive shells
./slow_action.sh
```



