### PR TITLE
fix andy-5/wslgit#46 - shell escape only when using bash to launch git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ target/
 **/*.rs.bk
 *.log
 *.patch
-.vscode
+.vscode/


### PR DESCRIPTION
- changed code to only shell escape when using
  "bash -ic" to launch git
- small refactor to reduce use of git_args vec and cloning
- added .vscode subdir to .gitignore