### PR TITLE
Improved shell_escape used for both interactive and non-interactive shell

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,16 +118,17 @@ fn main() {
 
     // process git command arguments
     git_args.extend(env::args().skip(1)
-        .map(translate_path_to_unix));
+        .map(translate_path_to_unix)
+        .map(shell_escape)
+    );
+    git_cmd = git_args.join(" ");
 
     if use_interactive_shell() {
         cmd_args.push("bash".to_string());
         cmd_args.push("-ic".to_string());
-        git_cmd = git_args.into_iter().map(shell_escape).collect::<Vec<String>>().join(" ");
         cmd_args.push(git_cmd.clone());
     }
     else {
-        git_cmd = git_args.join(" ");
         cmd_args = git_args;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,52 @@ fn main() {
     }
 }
 
+#[test]
+fn test_shell_escape_newline() {
+    assert_eq!(
+        shell_escape("ab\ncdef".to_string()),
+        "ab$\'\n\'cdef");
+    assert_eq!(
+        shell_escape("ab\ncd ef".to_string()),
+        "'ab$\'\n\'cd ef'");
+    // Long arguments with newlines...
+    assert_eq!(
+        shell_escape("--ab\ncdef".to_string()),
+        "--ab$\'\n\'cdef");
+    assert_eq!(
+        shell_escape("--ab\ncd ef".to_string()),
+        "--ab$\'\n\'cd ef");
+}
+
+#[test]
+fn test_shell_escape_invalid_character() {
+    assert_eq!(
+        shell_escape("abc def".to_string()),
+        "'abc def'");
+    assert_eq!(
+        shell_escape("abc(def".to_string()),
+        "'abc(def'");
+    assert_eq!(
+        shell_escape("abc)def".to_string()),
+        "'abc)def'");
+    assert_eq!(
+        shell_escape("abc|def".to_string()),
+        "'abc|def'");
+    // Long arguments should not be quoted.
+    assert_eq!(
+        shell_escape("--abc def".to_string()),
+        "--abc def");
+    // Long arguments with invalid characters...
+    assert_eq!(
+        shell_escape("--abc(def".to_string()),
+        "--abc(def");
+    assert_eq!(
+        shell_escape("--abc)def".to_string()),
+        "--abc)def");
+    assert_eq!(
+        shell_escape("--abc|def".to_string()),
+        "--abc|def");
+}
 
 #[test]
 fn win_to_unix_path_trans() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,16 +79,22 @@ fn translate_path_to_win(line: &[u8]) -> Cow<[u8]> {
     WSLPATH_RE.replace_all(line, &b"${drive}:${path}"[..])
 }
 
-fn shell_escape(arg: String) -> String {
-    // ToDo: This really only handles arguments with spaces and newlines.
-    // More complete shell escaping is required for the general case.
-    if arg.contains(" ") {
-        return vec![
-            String::from("\""),
-            arg,
-            String::from("\"")].join("");
+fn invalid_character(ch: char) -> bool {
+    match ch {
+        ' ' | '(' | ')' | '|' => true,
+        _ => false,
     }
-    arg.replace("\n", "$'\n'")
+}
+
+fn shell_escape(arg: String) -> String {
+    let mut argument: String = arg.replace("\n", "$'\n'");
+
+    if arg.contains(invalid_character) &&
+        !arg.starts_with("--") {
+        argument = format!("\'{}\'", argument);
+    }
+
+    return argument;
 }
 
 fn use_interactive_shell() -> bool {


### PR DESCRIPTION
Changed the `shell_escape` function to always escape newline and quote arguments in single-quote if they contain invalid characters (' ', (, ), and |), but only if the argument is not a long argument (starts with --).  
`shell_escape` is called for both interactive and non-interactive shell.

This fixes #73 and #54 and #46 still works, verified with
```
wslgit.exe config --get-regex "user.(name|email)"
wslgit.exe log --name-status --format="%x3c%x2ff%x3e%n%x3cr%x3e %H%n%x3ca%x3e %an%n%x3ce%x3e %ae%n%x3cd%x3e %at%n%x3cp%x3e %P%n%x3cs%x3e%n%B%n%x3c%x2fs%x3e%n%x3cf%x3e" -n200
```