### PR TITLE
Shell escape continued

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ license = "MIT"
 [dependencies]
 regex = "1"
 lazy_static = "1.3"
+
+[dev-dependencies]
+assert_cli = "0.6"

--- a/README.md
+++ b/README.md
@@ -104,3 +104,12 @@ cargo build --release
 inside the root directory of this project. The resulting binary will
 be located in `./target/release/`.
 
+Tests **must** be run using one test thread because of race conditions when changing environment variables:
+```bash
+# Run all tests
+cargo test -- --test-threads=1
+# Run only unit tests
+cargo test test -- --test-threads=1
+# Run only integration tests
+cargo test integration -- --test-threads=1
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,14 @@ fn use_interactive_shell() -> bool {
 
 fn main() {
     let mut cmd_args = Vec::new();
-    let mut git_args: Vec<String> = vec![String::from("git")];
+    let cwd_unix =
+        translate_path_to_unix(env::current_dir().unwrap().to_string_lossy().into_owned());
+    let mut git_args: Vec<String> = vec![
+        String::from("cd"),
+        cwd_unix,
+        String::from("&&"),
+        String::from("git"),
+    ];
     let git_cmd: String;
 
     // process git command arguments

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,13 +115,8 @@ fn use_interactive_shell() -> bool {
 
 fn main() {
     let mut cmd_args = Vec::new();
-    let cwd_unix =
-        translate_path_to_unix(env::current_dir().unwrap().to_string_lossy().into_owned());
     let mut git_args: Vec<String> = vec![
-        String::from("cd"),
-        cwd_unix,
-        String::from("&&"),
-        String::from("git"),
+        String::from("git")
     ];
     let git_cmd: String;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,8 +3,15 @@ extern crate assert_cli;
 
 #[cfg(test)]
 mod integration {
-    #[test]
-    fn simple_argument() {
+    fn use_interactive_env() {
+        ::std::env::set_var("WSLGIT_USE_INTERACTIVE_SHELL", "true");
+    }
+
+    fn use_non_interactive_env() {
+        ::std::env::set_var("WSLGIT_USE_INTERACTIVE_SHELL", "false");
+    }
+
+    fn simple_argument_test() {
         assert_cmd!(wslgit "--version")
             .succeeds()
             .stdout()
@@ -13,7 +20,18 @@ mod integration {
     }
 
     #[test]
-    fn argument_with_invalid_characters() {
+    fn simple_argument_interactive() {
+        use_interactive_env();
+        simple_argument_test();
+    }
+
+    #[test]
+    fn simple_argument_non_interactive() {
+        use_non_interactive_env();
+        simple_argument_test();
+    }
+
+    fn argument_with_invalid_characters_test() {
         // https://github.com/andy-5/wslgit/issues/54
         assert_cmd!(wslgit config "--get-regex" "user.(name|email)")
             .succeeds()
@@ -22,27 +40,82 @@ mod integration {
             .stdout()
             .contains("user.email")
             .unwrap();
-        assert_cmd!(wslgit config "--get-regex" "user.(name|email|`$&)")
+    }
+
+    #[test]
+    fn argument_with_invalid_characters_interactive() {
+        use_interactive_env();
+        argument_with_invalid_characters_test();
+    }
+
+    #[test]
+    fn argument_with_invalid_characters_non_interactive() {
+        use_non_interactive_env();
+        argument_with_invalid_characters_test();
+    }
+
+    fn quoted_argument_with_invalid_character_test() {
+        assert_cmd!(wslgit log "-n1" "--pretty=\"format:(X|Y)\"")
             .succeeds()
             .stdout()
-            .contains("user.name")
-            .stdout()
-            .contains("user.email")
+            .is("(X|Y)")
             .unwrap();
     }
 
     #[test]
-    fn argument_with_newline() {
+    fn quoted_argument_with_invalid_character_interactive() {
+        use_interactive_env();
+        quoted_argument_with_invalid_character_test();
+    }
+
+    #[test]
+    fn quoted_argument_with_invalid_character_non_interactive() {
+        use_non_interactive_env();
+        quoted_argument_with_invalid_character_test();
+    }
+
+    fn quoted_argument_with_invalid_character_and_space_test() {
+        assert_cmd!(wslgit log "-n1" "--pretty=\"format:( X | Y )\"")
+            .succeeds()
+            .stdout()
+            .is("( X | Y )")
+            .unwrap();
+    }
+
+    #[test]
+    fn quoted_argument_with_invalid_character_and_space_interactive() {
+        use_interactive_env();
+        quoted_argument_with_invalid_character_and_space_test();
+    }
+
+    #[test]
+    fn quoted_argument_with_invalid_character_and_space_non_interactive() {
+        use_non_interactive_env();
+        quoted_argument_with_invalid_character_and_space_test();
+    }
+
+    fn argument_with_newline_test() {
         // https://github.com/andy-5/wslgit/issues/73
-        assert_cmd!(wslgit log "-n1" "--pretty=format:ab\ncd")
+        assert_cmd!(wslgit log "-n1" "--pretty=format:XX\nYY")
             .succeeds()
             .stdout()
-            .is("ab\ncd")
+            .is("XX\nYY")
             .unwrap();
     }
 
     #[test]
-    fn short_argument_with_parameter_after_space() {
+    fn argument_with_newline_interactive() {
+        use_interactive_env();
+        argument_with_newline_test();
+    }
+
+    #[test]
+    fn argument_with_newline_non_interactive() {
+        use_non_interactive_env();
+        argument_with_newline_test();
+    }
+
+    fn short_argument_with_parameter_after_space_test() {
         // This is really stupid, hopefully first line of Cargo.toml won't change.
         assert_cmd!(wslgit log "-n1" "-L 1,1:Cargo.toml" "--" "Cargo.toml")
             .succeeds()
@@ -54,12 +127,29 @@ mod integration {
     }
 
     #[test]
-    fn long_argument_with_invalid_characters_and_spaces() {
+    fn short_argument_with_parameter_after_space_interactive() {
+        use_interactive_env();
+        short_argument_with_parameter_after_space_test();
+    }
+
+    #[test]
+    fn short_argument_with_parameter_after_space_non_interactive() {
+        use_non_interactive_env();
+        short_argument_with_parameter_after_space_test();
+    }
+
+    fn long_argument_with_invalid_characters_and_spaces_test() {
         assert_cmd!(wslgit log "-n1" "--pretty=format:a ( b | c )")
             .succeeds()
             .stdout()
             .is("a ( b | c )")
             .unwrap();
+
+        assert_cmd!(wslgit "for-each-ref" "refs/tags" "--format=%(refname) %(objectname)")
+            .succeeds()
+            .stdout().contains("refs/tags/v0.1.0 c313ea9f9667e346ace079b47dc0d9f991fb5ab7\nrefs/tags/v0.2.0 43e0817f6c711abbcc5fe20bf7656fd26193fc0f")
+            .unwrap();
+
         assert_cmd!(wslgit "for-each-ref" "refs/tags" "--format=%(refname) %(objectname)")
             .succeeds()
             .stdout().contains("refs/tags/v0.1.0 c313ea9f9667e346ace079b47dc0d9f991fb5ab7\nrefs/tags/v0.2.0 43e0817f6c711abbcc5fe20bf7656fd26193fc0f")
@@ -67,25 +157,73 @@ mod integration {
     }
 
     #[test]
-    fn long_argument_with_invalid_characters_no_spaces() {
+    fn long_argument_with_invalid_characters_and_spaces_interactive() {
+        use_interactive_env();
+        long_argument_with_invalid_characters_and_spaces_test();
+    }
+
+    #[test]
+    fn long_argument_with_invalid_characters_and_spaces_non_interactive() {
+        use_non_interactive_env();
+        long_argument_with_invalid_characters_and_spaces_test();
+    }
+
+    fn long_argument_with_invalid_characters_no_spaces_test() {
         assert_cmd!(wslgit log "-n1" "--pretty=format:a(b|c)")
             .succeeds()
             .stdout()
             .is("a(b|c)")
             .unwrap();
+    }
+
+    #[test]
+    fn long_argument_with_invalid_characters_no_spaces_interactive() {
+        use_interactive_env();
+        long_argument_with_invalid_characters_no_spaces_test();
+
+        assert_cmd!(wslgit "for-each-ref" "refs/tags" "--format=%(refname)%(objectname)")
+            .succeeds()
+            .stdout().contains("refs/tags/v0.1.0c313ea9f9667e346ace079b47dc0d9f991fb5ab7\nrefs/tags/v0.2.043e0817f6c711abbcc5fe20bf7656fd26193fc0f\n")
+            .unwrap();
+    }
+
+    #[test]
+    fn long_argument_with_invalid_characters_no_spaces_non_interactive() {
+        use_non_interactive_env();
+        long_argument_with_invalid_characters_no_spaces_test();
+
         assert_cmd!(wslgit "for-each-ref" "refs/tags" "--format=%(refname)%(objectname)")
             .succeeds()
             .stdout().contains("refs/tags/v0.1.0c313ea9f9667e346ace079b47dc0d9f991fb5ab7 \nrefs/tags/v0.2.043e0817f6c711abbcc5fe20bf7656fd26193fc0f \n")
             .unwrap();
     }
 
-    #[test]
-    fn long_argument() {
+    fn long_argument_test() {
         // https://github.com/andy-5/wslgit/issues/46
+        use_interactive_env();
         assert_cmd!(wslgit log "-n1" "--format=%x3c%x2ff%x3e%n%x3cr%x3e 01234%n%x3ca%x3e abcd")
             .succeeds()
             .stdout()
             .is("</f>\n<r> 01234\n<a> abcd")
             .unwrap();
+
+        use_non_interactive_env();
+        assert_cmd!(wslgit log "-n1" "--format=%x3c%x2ff%x3e%n%x3cr%x3e 01234%n%x3ca%x3e abcd")
+            .succeeds()
+            .stdout()
+            .is("</f>\n<r> 01234\n<a> abcd")
+            .unwrap();
+    }
+
+    #[test]
+    fn long_argument_interactive() {
+        use_interactive_env();
+        long_argument_test();
+    }
+
+    #[test]
+    fn long_argument_non_interactive() {
+        use_non_interactive_env();
+        long_argument_test();
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,91 @@
+#[macro_use]
+extern crate assert_cli;
+
+#[cfg(test)]
+mod integration {
+    #[test]
+    fn simple_argument() {
+        assert_cmd!(wslgit "--version")
+            .succeeds()
+            .stdout()
+            .contains("git version")
+            .unwrap();
+    }
+
+    #[test]
+    fn argument_with_invalid_characters() {
+        // https://github.com/andy-5/wslgit/issues/54
+        assert_cmd!(wslgit config "--get-regex" "user.(name|email)")
+            .succeeds()
+            .stdout()
+            .contains("user.name")
+            .stdout()
+            .contains("user.email")
+            .unwrap();
+        assert_cmd!(wslgit config "--get-regex" "user.(name|email|`$&)")
+            .succeeds()
+            .stdout()
+            .contains("user.name")
+            .stdout()
+            .contains("user.email")
+            .unwrap();
+    }
+
+    #[test]
+    fn argument_with_newline() {
+        // https://github.com/andy-5/wslgit/issues/73
+        assert_cmd!(wslgit log "-n1" "--pretty=format:ab\ncd")
+            .succeeds()
+            .stdout()
+            .is("ab\ncd")
+            .unwrap();
+    }
+
+    #[test]
+    fn short_argument_with_parameter_after_space() {
+        // This is really stupid, hopefully first line of Cargo.toml won't change.
+        assert_cmd!(wslgit log "-n1" "-L 1,1:Cargo.toml" "--" "Cargo.toml")
+            .succeeds()
+            .stdout()
+            .contains("diff --git a/Cargo.toml b/Cargo.toml")
+            .stdout()
+            .contains("@@ -0,0 +1,1 @@")
+            .unwrap();
+    }
+
+    #[test]
+    fn long_argument_with_invalid_characters_and_spaces() {
+        assert_cmd!(wslgit log "-n1" "--pretty=format:a ( b | c )")
+            .succeeds()
+            .stdout()
+            .is("a ( b | c )")
+            .unwrap();
+        assert_cmd!(wslgit "for-each-ref" "refs/tags" "--format=%(refname) %(objectname)")
+            .succeeds()
+            .stdout().contains("refs/tags/v0.1.0 c313ea9f9667e346ace079b47dc0d9f991fb5ab7\nrefs/tags/v0.2.0 43e0817f6c711abbcc5fe20bf7656fd26193fc0f")
+            .unwrap();
+    }
+
+    #[test]
+    fn long_argument_with_invalid_characters_no_spaces() {
+        assert_cmd!(wslgit log "-n1" "--pretty=format:a(b|c)")
+            .succeeds()
+            .stdout()
+            .is("a(b|c)")
+            .unwrap();
+        assert_cmd!(wslgit "for-each-ref" "refs/tags" "--format=%(refname)%(objectname)")
+            .succeeds()
+            .stdout().contains("refs/tags/v0.1.0c313ea9f9667e346ace079b47dc0d9f991fb5ab7 \nrefs/tags/v0.2.043e0817f6c711abbcc5fe20bf7656fd26193fc0f \n")
+            .unwrap();
+    }
+
+    #[test]
+    fn long_argument() {
+        // https://github.com/andy-5/wslgit/issues/46
+        assert_cmd!(wslgit log "-n1" "--format=%x3c%x2ff%x3e%n%x3cr%x3e 01234%n%x3ca%x3e abcd")
+            .succeeds()
+            .stdout()
+            .is("</f>\n<r> 01234\n<a> abcd")
+            .unwrap();
+    }
+}


### PR DESCRIPTION
* Improved shell_escape():
  * Arguments with invalid characters and _spaces_ should not be quoted since the space cause them to be quoted elsewhere.
  * Long arguments (--argname) and flag arguments (-f) that have invalid characters are not quoted, instead a space i appended so they also get quoted elsewhere.
  * Other arguments are enclosed in single-quotes.
* Added integration tests using *assert_cli*.

#54

