### PR TITLE
Mount root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,6 @@ name = "wslgit"
 version = "0.8.0"
 dependencies = [
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT"
 
 [dependencies]
 regex = "1"
-lazy_static = "1.3"
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This feature is only available in Windows 10 builds 17063 and later.
 The default mount root is `/mnt/`, but if it has been changed using `/etc/wsl.conf`
 then `wslgit` must be instructed to use the correct mount root by, in Windows,
 setting the environment variable `WSLGIT_MOUNT_ROOT` to the new root path.  
-If, for example, the mount root defined in wsl.conf is `/` then set *WSLGIT_MOUNT_ROOT* to just `/`.
+If, for example, the mount root defined in wsl.conf is `/` then set `WSLGIT_MOUNT_ROOT` to just `/`.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,14 @@ two methods:
     from `BASH_ENV` contains everything you need, and therefore also starts
     bash in non-interactive mode.
 
-    This feature is only available in Windows 10 builds 17063 and later.
+This feature is only available in Windows 10 builds 17063 and later.
 
+## Mount Root
+
+The default mount root is `/mnt/`, but if it has been changed using `/etc/wsl.conf`
+then `wslgit` must be instructed to use the correct mount root by, in Windows,
+setting the environment variable `WSLGIT_MOUNT_ROOT` to the new root path.  
+If, for example, the mount root defined in wsl.conf is `/` then set *WSLGIT_MOUNT_ROOT* to just `/`.
 
 ## Building from source
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,7 @@ fn mount_root() -> String {
 }
 
 fn get_prefix_for_drive(drive: &str) -> String {
-    // todo - lookup mount points
-    format!("/mnt/{}", drive)
+    format!("{}{}", mount_root(), drive)
 }
 
 fn translate_path_to_unix(argument: String) -> String {
@@ -293,6 +292,7 @@ mod tests {
 
     #[test]
     fn win_to_unix_path_trans() {
+        env::remove_var("WSLGIT_MOUNT_ROOT");
         assert_eq!(
             translate_path_to_unix("d:\\test\\file.txt".to_string()),
             "/mnt/d/test/file.txt"
@@ -300,6 +300,26 @@ mod tests {
         assert_eq!(
             translate_path_to_unix("C:\\Users\\test\\a space.txt".to_string()),
             "/mnt/c/Users/test/a space.txt"
+        );
+
+        env::set_var("WSLGIT_MOUNT_ROOT", "/abc/");
+        assert_eq!(
+            translate_path_to_unix("d:\\test\\file.txt".to_string()),
+            "/abc/d/test/file.txt"
+        );
+        assert_eq!(
+            translate_path_to_unix("C:\\Users\\test\\a space.txt".to_string()),
+            "/abc/c/Users/test/a space.txt"
+        );
+
+        env::set_var("WSLGIT_MOUNT_ROOT", "/");
+        assert_eq!(
+            translate_path_to_unix("d:\\test\\file.txt".to_string()),
+            "/d/test/file.txt"
+        );
+        assert_eq!(
+            translate_path_to_unix("C:\\Users\\test\\a space.txt".to_string()),
+            "/c/Users/test/a space.txt"
         );
     }
 
@@ -331,6 +351,19 @@ mod tests {
 
     #[test]
     fn relative_path_translation() {
+        env::remove_var("WSLGIT_MOUNT_ROOT");
+        assert_eq!(
+            translate_path_to_unix(".\\src\\main.rs".to_string()),
+            "./src/main.rs"
+        );
+
+        env::set_var("WSLGIT_MOUNT_ROOT", "/abc/");
+        assert_eq!(
+            translate_path_to_unix(".\\src\\main.rs".to_string()),
+            "./src/main.rs"
+        );
+
+        env::set_var("WSLGIT_MOUNT_ROOT", "/");
         assert_eq!(
             translate_path_to_unix(".\\src\\main.rs".to_string()),
             "./src/main.rs"
@@ -339,9 +372,22 @@ mod tests {
 
     #[test]
     fn long_argument_path_translation() {
+        env::remove_var("WSLGIT_MOUNT_ROOT");
         assert_eq!(
             translate_path_to_unix("--file=C:\\some\\path.txt".to_owned()),
             "--file=/mnt/c/some/path.txt"
+        );
+
+        env::set_var("WSLGIT_MOUNT_ROOT", "/abc/");
+        assert_eq!(
+            translate_path_to_unix("--file=C:\\some\\path.txt".to_owned()),
+            "--file=/abc/c/some/path.txt"
+        );
+
+        env::set_var("WSLGIT_MOUNT_ROOT", "/");
+        assert_eq!(
+            translate_path_to_unix("--file=C:\\some\\path.txt".to_owned()),
+            "--file=/c/some/path.txt"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,19 @@ fn get_drive_letter(pc: &PrefixComponent) -> Option<String> {
     })
 }
 
+fn mount_root() -> String {
+    match env::var("WSLGIT_MOUNT_ROOT") {
+        Ok(val) => {
+            if val.ends_with("/") {
+                return val;
+            } else {
+                return format!("{}/", val);
+            }
+        }
+        Err(_e) => return "/mnt/".to_string(),
+    }
+}
+
 fn get_prefix_for_drive(drive: &str) -> String {
     // todo - lookup mount points
     format!("/mnt/{}", drive)
@@ -206,6 +219,22 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mount_root_test() {
+        env::remove_var("WSLGIT_MOUNT_ROOT");
+        assert_eq!(mount_root(), "/mnt/");
+
+        env::set_var("WSLGIT_MOUNT_ROOT", "/abc/");
+        assert_eq!(mount_root(), "/abc/");
+
+        env::set_var("WSLGIT_MOUNT_ROOT", "/abc");
+        assert_eq!(mount_root(), "/abc/");
+
+        env::set_var("WSLGIT_MOUNT_ROOT", "/");
+        assert_eq!(mount_root(), "/");
+    }
+
     #[test]
     fn escape_newline() {
         assert_eq!(


### PR DESCRIPTION
Implemented support for custom mount root using WSLGIT_MOUNT_ROOT environment variable as mentioned in this [comment](https://github.com/andy-5/wslgit/issues/12#issuecomment-502403600).