### PR TITLE
Bugfixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ name = "wslgit"
 version = "0.8.0"
 dependencies = [
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [dependencies]
 regex = "1"
+lazy_static = "1.3"
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn get_prefix_for_drive(drive: &str) -> String {
 
 fn translate_path_to_unix(argument: String) -> String {
     {
-        let (argname, arg) = if argument.starts_with("--") && argument.contains('=') {
+        let (argname, arg) = if argument.contains('=') {
             let parts: Vec<&str> = argument.splitn(2, '=').collect();
             (format!("{}=", parts[0]), parts[1])
         } else {
@@ -406,11 +406,16 @@ mod tests {
     }
 
     #[test]
-    fn long_argument_path_translation() {
+    fn arguments_path_translation() {
         env::remove_var("WSLGIT_MOUNT_ROOT");
         assert_eq!(
             translate_path_to_unix("--file=C:\\some\\path.txt".to_owned()),
             "--file=/mnt/c/some/path.txt"
+        );
+
+        assert_eq!(
+            translate_path_to_unix("-c core.editor=C:\\some\\editor.exe".to_owned()),
+            "-c core.editor=/mnt/c/some/editor.exe"
         );
 
         env::set_var("WSLGIT_MOUNT_ROOT", "/abc/");
@@ -419,10 +424,20 @@ mod tests {
             "--file=/abc/c/some/path.txt"
         );
 
+        assert_eq!(
+            translate_path_to_unix("-c core.editor=C:\\some\\editor.exe".to_owned()),
+            "-c core.editor=/abc/c/some/editor.exe"
+        );
+
         env::set_var("WSLGIT_MOUNT_ROOT", "/");
         assert_eq!(
             translate_path_to_unix("--file=C:\\some\\path.txt".to_owned()),
             "--file=/c/some/path.txt"
+        );
+
+        assert_eq!(
+            translate_path_to_unix("-c core.editor=C:\\some\\editor.exe".to_owned()),
+            "-c core.editor=/c/some/editor.exe"
         );
     }
 }


### PR DESCRIPTION
This is the last one, I promise :)

* Fixes the BASH_ENV in WSLENV detection (bug #56)
  * If *WSLGIT_USE_INTERACTIVE_SHELL* is set it will always be used to determine if using interactive or not.
* Fixed conversion to unix-paths in all arguments containing '='.
  * For arguments like `-c core.editor=C:\\some\\editor.exe`

