### PR TITLE
Using wslpath for translating absolute paths Win<->WSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ regex = "1"
 lazy_static = "1.3"
 
 [dev-dependencies]
-assert_cli = "0.6"
+assert_cmd = "0.11"
+predicates = "1.0"

--- a/README.md
+++ b/README.md
@@ -118,4 +118,6 @@ cargo test -- --test-threads=1
 cargo test test -- --test-threads=1
 # Run only integration tests
 cargo test integration -- --test-threads=1
+# Run benchmarks (requires nightly toolchain!)
+cargo +nightly bench
 ```

--- a/README.md
+++ b/README.md
@@ -89,13 +89,6 @@ two methods:
 
 This feature is only available in Windows 10 builds 17063 and later.
 
-## Mount Root
-
-The default mount root is `/mnt/`, but if it has been changed using `/etc/wsl.conf`
-then `wslgit` must be instructed to use the correct mount root by, in Windows,
-setting the environment variable `WSLGIT_MOUNT_ROOT` to the new root path.  
-If, for example, the mount root defined in wsl.conf is `/` then set `WSLGIT_MOUNT_ROOT` to just `/`.
-
 ## Building from source
 
 First, install Rust from https://www.rust-lang.org. Rust on Windows also

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,0 +1,60 @@
+#![feature(test)]
+extern crate test;
+
+#[cfg(test)]
+mod bench {
+    use std::env;
+    use std::process::Command;
+    use test::Bencher;
+
+    #[bench]
+    fn no_translation(b: &mut Bencher) {
+        b.iter(|| {
+            Command::new("wslgit")
+                .args(&["--version"])
+                .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+                .output()
+        })
+    }
+
+    #[bench]
+    fn translate_absolute_argument(b: &mut Bencher) {
+        let p = env::current_dir()
+            .unwrap()
+            .as_path()
+            .join("src\\main.rs")
+            .as_path()
+            .to_string_lossy()
+            .into_owned();
+        let file_path = p.as_str();
+
+        b.iter(|| {
+            Command::new("wslgit")
+                .args(&["log", "-n1", "--oneline", "--", file_path])
+                .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+                .output()
+        })
+    }
+
+    #[bench]
+    fn translate_relative_argument(b: &mut Bencher) {
+        let file_path = "src\\main.rs";
+
+        b.iter(|| {
+            Command::new("wslgit")
+                .args(&["log", "-n1", "--oneline", "--", file_path])
+                .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+                .output()
+        })
+    }
+
+    #[bench]
+    fn translate_output(b: &mut Bencher) {
+        b.iter(|| {
+            Command::new("wslgit")
+                .args(&["rev-parse", "--show-toplevel"])
+                .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+                .output()
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,7 +233,7 @@ fn main() {
     let status;
 
     // add git commands that must use translate_path_to_win
-    const TRANSLATED_CMDS: &[&str] = &["rev-parse", "remote"];
+    const TRANSLATED_CMDS: &[&str] = &["rev-parse", "remote", "init"];
 
     let translate_output = env::args()
         .skip(1)

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,14 +157,7 @@ fn use_interactive_shell() -> bool {
 
 fn main() {
     let mut cmd_args = Vec::new();
-    let cwd_unix =
-        translate_path_to_unix(env::current_dir().unwrap().to_string_lossy().into_owned());
-    let mut git_args: Vec<String> = vec![
-        String::from("cd"),
-        format!("\"{}\"", cwd_unix),
-        String::from("&&"),
-        String::from("git"),
-    ];
+    let mut git_args: Vec<String> = vec![String::from("git")];
 
     git_args.extend(
         env::args()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,111 +1,164 @@
-#[macro_use]
-extern crate assert_cli;
+extern crate assert_cmd;
+extern crate predicates;
 
 #[cfg(test)]
 mod integration {
+    use assert_cmd::prelude::*;
+    use predicates::prelude::*;
+    use std::process::Command;
+
     #[test]
     fn simple_argument() {
-        assert_cmd!(wslgit "--version")
-            .succeeds()
-            .stdout()
-            .contains("git version")
-            .unwrap();
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .arg("--version")
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("git version"));
     }
 
     #[test]
     fn argument_with_invalid_characters() {
         // https://github.com/andy-5/wslgit/issues/54
-        assert_cmd!(wslgit config "--get-regex" "user.(name|email)")
-            .succeeds()
-            .stdout()
-            .contains("user.name")
-            .stdout()
-            .contains("user.email")
-            .unwrap();
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&["config", "--get-regex", "user.(name|email)"])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("user.name"))
+            .stdout(predicate::str::contains("user.email"));
     }
 
     #[test]
     fn quoted_argument_with_invalid_character() {
-        assert_cmd!(wslgit log "-n1" "--pretty=\"format:(X|Y)\"")
-            .succeeds()
-            .stdout()
-            .is("(X|Y)")
-            .unwrap();
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&["log", "-n1", "--pretty=\"format:(X|Y)\""])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout("(X|Y)");
     }
 
     #[test]
     fn strangely_quoted_argument() {
-        assert_cmd!(wslgit log "-n1" "--pr\"etty=format:(X|Y)\"")
-            .succeeds()
-            .stdout()
-            .is("(X|Y)")
-            .unwrap();
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&["log", "-n1", "--pr\"etty=format:(X|Y)\""])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout("(X|Y)");
     }
 
     #[test]
     fn quoted_argument_with_invalid_character_and_spaces() {
-        assert_cmd!(wslgit log "-n1" "--pretty=\"format:( X | Y )\"")
-            .succeeds()
-            .stdout()
-            .is("( X | Y )")
-            .unwrap();
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&["log", "-n1", "--pretty=\"format:( X | Y )\""])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout("( X | Y )");
     }
 
     #[test]
     fn argument_with_newline() {
-        // https://github.com/andy-5/wslgit/issues/73
-        assert_cmd!(wslgit log "-n1" "--pretty=format:ab\ncd")
-            .succeeds()
-            .stdout()
-            .is("ab\ncd")
-            .unwrap();
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&["log", "-n1", "--pretty=format:ab\ncd"])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout("ab\ncd");
     }
 
     #[test]
     fn short_argument_with_parameter_after_space() {
         // This is really stupid, hopefully first line of Cargo.toml won't change.
-        assert_cmd!(wslgit log "-n1" "-L 1,1:Cargo.toml" "--" "Cargo.toml")
-            .succeeds()
-            .stdout()
-            .contains("diff --git a/Cargo.toml b/Cargo.toml")
-            .stdout()
-            .contains("@@ -0,0 +1,1 @@")
-            .unwrap();
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&["log", "-n1", "-L 1,1:Cargo.toml", "--", "Cargo.toml"])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "diff --git a/Cargo.toml b/Cargo.toml",
+            ))
+            .stdout(predicate::str::contains("@@ -0,0 +1,1 @@"));
     }
 
     #[test]
     fn long_argument_with_invalid_characters_and_spaces() {
-        assert_cmd!(wslgit log "-n1" "--pretty=format:a ( b | c )")
-            .succeeds()
-            .stdout()
-            .is("a ( b | c )")
-            .unwrap();
-        assert_cmd!(wslgit "for-each-ref" "refs/tags" "--format=%(refname) %(objectname)")
-            .succeeds()
-            .stdout().contains("refs/tags/v0.1.0 c313ea9f9667e346ace079b47dc0d9f991fb5ab7\nrefs/tags/v0.2.0 43e0817f6c711abbcc5fe20bf7656fd26193fc0f")
-            .unwrap();
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&["log", "-n1", "--pretty=format:a ( b | c )"])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout("a ( b | c )");
+
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&[
+                "for-each-ref",
+                "refs/tags",
+                "--format=%(refname) %(objectname)",
+            ])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "refs/tags/v0.1.0 c313ea9f9667e346ace079b47dc0d9f991fb5ab7",
+            ))
+            .stdout(predicate::str::contains(
+                "refs/tags/v0.2.0 43e0817f6c711abbcc5fe20bf7656fd26193fc0f",
+            ));
     }
 
     #[test]
     fn long_argument_with_invalid_characters_no_spaces() {
-        assert_cmd!(wslgit log "-n1" "--pretty=format:a(b|c)")
-            .succeeds()
-            .stdout()
-            .is("a(b|c)")
-            .unwrap();
-        assert_cmd!(wslgit "for-each-ref" "refs/tags" "--format=%(refname)%(objectname)")
-            .succeeds()
-            .stdout().contains("refs/tags/v0.1.0c313ea9f9667e346ace079b47dc0d9f991fb5ab7\nrefs/tags/v0.2.043e0817f6c711abbcc5fe20bf7656fd26193fc0f\n")
-            .unwrap();
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&["log", "-n1", "--pretty=format:a(b|c)"])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout("a(b|c)");
+
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&[
+                "for-each-ref",
+                "refs/tags",
+                "--format=%(refname)%(objectname)",
+            ])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "refs/tags/v0.1.0c313ea9f9667e346ace079b47dc0d9f991fb5ab7",
+            ))
+            .stdout(predicate::str::contains(
+                "refs/tags/v0.2.043e0817f6c711abbcc5fe20bf7656fd26193fc0f",
+            ));
     }
 
     #[test]
     fn long_argument() {
         // https://github.com/andy-5/wslgit/issues/46
-        assert_cmd!(wslgit log "-n1" "--format=%x3c%x2ff%x3e%n%x3cr%x3e 01234%n%x3ca%x3e abcd")
-            .succeeds()
-            .stdout()
-            .is("</f>\n<r> 01234\n<a> abcd")
-            .unwrap();
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&[
+                "log",
+                "-n1",
+                "--format=%x3c%x2ff%x3e%n%x3cr%x3e 01234%n%x3ca%x3e abcd",
+            ])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout("</f>\n<r> 01234\n<a> abcd\n");
     }
 }


### PR DESCRIPTION
I've implemented using `wslpath` to translate win-paths to wsl-paths and vice versa.

The translation from windows to wsl path is as fast as the previous implementation, but the wsl to windows path translation gets a ~60ms penalty because of one extra process invoke of the output from the git command.

- Using `wslpath` to translate absolute paths. #12
  - Supports paths like `\\server\share` **if** the same path is mounted in WSL (see [Mounting network locations](https://blogs.msdn.microsoft.com/wsl/2017/04/18/file-system-improvements-to-the-windows-subsystem-for-linux/)).
  - Supports `\\wsl$`. #71
  - Supports any mount paths (`/c`, `/mnt/c`, `/my/mount/path/c`, etc), so no need for `WSLGIT_MOUNT_ROOT` anymore.
  - Supports manually mounted paths (not in fstab or automounted).
- Works with `log -L 1,1:C:\path\to\file` and `log -L :funcname:C:\path\to\file`
- Implemented benchmarks.  
- Added a simple file log that can be enabled to log input arguments and the resulting git command, as well as the output translation.
- Changed from assert_cli to assert_cmd crate for testing CLI. 


**Benchmark results:**
```
Before wslpath:
test bench::no_translation              ... bench:  60,846,590 ns/iter (+/- 11,856,476)
test bench::translate_absolute_argument ... bench:  71,600,430 ns/iter (+/- 2,973,202)
test bench::translate_output            ... bench:  56,521,180 ns/iter (+/- 3,329,437)
test bench::translate_relative_argument ... bench:  62,603,140 ns/iter (+/- 3,727,496)

Using wslpath:
test bench::no_translation              ... bench:  60,685,500 ns/iter (+/- 13,579,360)
test bench::translate_absolute_argument ... bench:  69,877,700 ns/iter (+/- 12,559,499)
test bench::translate_output            ... bench: 110,932,150 ns/iter (+/- 4,230,732)
test bench::translate_relative_argument ... bench:  61,110,610 ns/iter (+/- 1,364,392)
```
