### PR TITLE
Smart interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,25 @@ Only spaces and newlines in arguments are currently handled.
 
 ## Advanced Usage
 
-Per default, `wslgit` executes `git` inside the WSL environment through bash
-started in interactive mode. This is to automatically support the common case
-where `ssh-agent` or similar tools are setup by `.bashrc` in interactive mode.
-However, this may significantly slow down the execution of git commands.
-To improve startup time, you can configure `wslgit` to execute git via a
-non-interactive bash session. This can be achieved using one of the following
-two methods:
+### WSLGIT_USE_INTERACTIVE_SHELL
+To automatically support the common case where `ssh-agent` or similar tools are 
+setup by `.bashrc` in interactive mode then, per default, `wslgit` executes `git` 
+inside the WSL environment through `bash` started in interactive mode for some 
+commands (`clone`, `fetch`, `pull` and `push`), and `bash` started in non-interactive 
+mode for all other commands.
 
-  - In Windows, set the environment variable `WSLGIT_USE_INTERACTIVE_SHELL` to
-    `false` or `0`. This forces `wslgit` to start bash in non-interactive mode.
-  - Alternatively, if the Windows environment variable `BASH_ENV` is set to
-    a bash startup script and the environment variable `WSLENV` contains the
-    string `"BASH_ENV"`, then `wslgit` assumes that the forced startup script
-    from `BASH_ENV` contains everything you need, and therefore also starts
-    bash in non-interactive mode.
+The behavior can be selected by setting an environment variable in Windows 
+named `WSLGIT_USE_INTERACTIVE_SHELL` to one of the following values:
+* `false` or `0` - Force `wslgit` to **always** start in **_non_-interactive** mode.
+* `true`, `1`, or empty value - Force `wslgit` to **always** start in **interactive** mode.
+* `smart` (default) - Interactive mode for `clone`, `fetch`, `pull`, `push`, 
+non-interactive mode for all other commands. This is the default if the variable is not set.
+
+Alternatively, if `WSLGIT_USE_INTERACTIVE_SHELL` is **not** set but the Windows 
+environment variable `BASH_ENV` is set to a bash startup script and the environment 
+variable `WSLENV` contains the string `"BASH_ENV"`, then `wslgit` assumes that 
+the forced startup script from `BASH_ENV` contains everything you need, and 
+therefore also starts bash in non-interactive mode.
 
 This feature is only available in Windows 10 builds 17063 and later.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ therefore also starts bash in non-interactive mode.
 
 This feature is only available in Windows 10 builds 17063 and later.
 
+### WSLGIT
+`wslgit` set a variable called `WSLGIT` to `1` and shares it to WSL. This variable can be used in `.bashrc` to 
+determine if WSL was invoked by `wslgit`, and for example if set then just do the absolute minimum of initialization 
+needed for `git` to function.  
+Combined with `WSLGIT_USE_INTERACTIVE_SHELL=smart` (default) this can make every git command execute with as little overhead as possible.
+
+This feature is only available in Windows 10 builds 17063 and later.
+
 ## Building from source
 
 First, install Rust from https://www.rust-lang.org. Rust on Windows also

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,19 @@ fn main() {
     // setup the git subprocess launched inside WSL
     let mut git_proc_setup = Command::new("wsl");
     git_proc_setup.args(&cmd_args);
+
+    git_proc_setup.env("WSLGIT", "1");
+    let wslenv = match env::var("WSLENV") {
+        Ok(wslenv) => {
+            if wslenv.is_empty() {
+                format!("WSLGIT")
+            } else {
+                format!("{}:WSLGIT", wslenv)
+            }
+        },
+        Err(_e) => format!("WSLGIT"),
+    };
+    env::set_var("WSLENV", wslenv);
     let status;
 
     // add git commands that must use translate_path_to_win

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -263,4 +263,29 @@ mod integration {
             .success()
             .stdout(cwd);
     }
+
+    #[test]
+    fn wslgit_environment_variable() {
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            // Use pretty format to call 'env'
+            .args(&["log", "-1", "--pretty=format:\"$(env)\""])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .env("WSLENV", "")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("WSLGIT=1"))
+            .stdout(predicate::str::contains("WSLENV=WSLGIT"));
+
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            // Use pretty format to call 'env'
+            .args(&["log", "-1", "--pretty=format:\"$(env)\""])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .env("WSLENV", "hello")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("WSLGIT=1"))
+            .stdout(predicate::str::contains("WSLENV=hello:WSLGIT"));
+    }
 }


### PR DESCRIPTION
When I implemented the benchmarks in #86 then I realized how much slower it was to use interactive mode versus non-interactive. I'm using an ssh-agent so I have to use interactive mode.

But it is not all git commands that needs the ssh-agent, just those who access remotes (`clone`, `fetch`, `pull` and `push` afaik). 
So I implemented a *smart* option for `WSLGIT_USE_INTERACTIVE_SHELL` that use interactive mode for just those commands. 
And why not make it the default. 

I also made `wslgit` share one environmental variable named `WSLGIT` to WSL which I use in my `.bashrc` to do the bare minimum of initialization for git to work.

My GUI tools that use `wslgit` feels a lot snappier now, and still use the ssh-agent for remote access :)