### PR TITLE
Fork patch cleanup 2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 Fork.RI     text eol=lf
+install.bat text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Fork.RI     text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 *.log
 *.patch
 .vscode/
+release/

--- a/README.md
+++ b/README.md
@@ -9,23 +9,33 @@ For these two to interoperate, this tool translates paths
 between the Windows (`C:\Foo\Bar`) and Linux (`/mnt/c/Foo/Bar`)
 representations.
 
-## Download
+## Installation
 
-The latest binary release can be found on the
+The latest binary release can be downloaded from the
 [releases page](https://github.com/andy-5/wslgit/releases).
+
+After unzipping the release run the `install.bat` script *as administrator* to 
+create the required symbolic links in the `wslgit\bin` folder.  
+
+Put the directory containing the executable (`wslgit\bin`) somewhere on your Windows `Path`
+environment variable (user or system).  
+To change the environment variable, type
+`Edit environment variables for your account` into Start menu/Windows search
+and use that tool to edit `Path`.
 
 You may also need to install the latest
 [*Microsoft Visual C++ Redistributable for Visual Studio 2017*](https://aka.ms/vs/15/release/vc_redist.x64.exe).
 
-
 ## Usage in VSCode
 
-To use this inside VSCode, put the `wslgit.exe` executable somewhere on
-your computer and set the appropriate path in your VSCode `settings.json`:
+VSCode will find the `git` executable in `wslgit\bin` automatically if the path  
+was added to the Windows `Path` environment variable.
+
+If not, set the appropriate path in your VSCode `settings.json`:
 
 ```
 {
-    "git.path": "C:\\CHANGE\\TO\\PATH\\TO\\wslgit.exe"
+    "git.path": "C:\\CHANGE\\TO\\PATH\\TO\\wslgit\\bin\\git.exe"
 }
 ```
 
@@ -42,13 +52,8 @@ Git plugin cannot correctly parse the output.
 
 ## Usage from the command line
 
-Put the directory containing the executable somewhere on your Windows `Path`
-environment variable and optionally rename `wslgit.exe` to `git.exe`.
-To change the environment variable, type
-`Edit environment variables for your account` into Start menu/Windows search
-and use that tool to edit `Path`.
-
-You can then just run any git command from a Windows console
+If you put the path to `wslgit\bin` on the Windows `Path` environment variable 
+you can then just run any git command from a Windows console
 by running `wslgit COMMAND` or `git COMMAND` and it uses the Git version
 installed in WSL.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ by running `wslgit COMMAND` or `git COMMAND` and it uses the Git version
 installed in WSL.
 
 
+## Usage in Fork
+[Fork](https://fork.dev) is a Git GUI tool for Windows (and Mac) that use its own portable version of `Git for Windows`.  
+To make Fork use `git from WSL` then go to the preferences and select a custom git instance where you point it to the `git.exe` in the `wslgit\bin` folder.
+
 ## Remarks
 
 Currently, the path translation and shell escaping is very limited,

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ representations.
 The latest binary release can be downloaded from the
 [releases page](https://github.com/andy-5/wslgit/releases).
 
-After unzipping the release run the `install.bat` script *as administrator* to 
-create the required symbolic links in the `wslgit\bin` folder.  
+**[Optional 1]** Run the `install.bat` script *as administrator*.  
+The `install.bat` script creates a folder structure similar to the one used by `Git For Windows`, 
+and creates some useful symbolic links in the `wslgit\cmd` and `wslgit\bin` folders.
 
-Put the directory containing the executable (`wslgit\bin`) somewhere on your Windows `Path`
+**[Optional 2]** Add the `wslgit\cmd` directory to your Windows `Path`
 environment variable (user or system).  
 To change the environment variable, type
 `Edit environment variables for your account` into Start menu/Windows search
@@ -28,14 +29,13 @@ You may also need to install the latest
 
 ## Usage in VSCode
 
-VSCode will find the `git` executable in `wslgit\bin` automatically if the path  
-was added to the Windows `Path` environment variable.
+VSCode will find the `git` executable automatically if the two optional installation steps were taken.
 
 If not, set the appropriate path in your VSCode `settings.json`:
 
 ```
 {
-    "git.path": "C:\\CHANGE\\TO\\PATH\\TO\\wslgit\\bin\\git.exe"
+    "git.path": "C:\\CHANGE\\TO\\PATH\\TO\\wslgit\\cmd\\wslgit.exe"
 }
 ```
 
@@ -52,15 +52,14 @@ Git plugin cannot correctly parse the output.
 
 ## Usage from the command line
 
-If you put the path to `wslgit\bin` on the Windows `Path` environment variable 
+If you did the two optional installation steps then 
 you can then just run any git command from a Windows console
 by running `wslgit COMMAND` or `git COMMAND` and it uses the Git version
 installed in WSL.
 
-
 ## Usage in Fork
-[Fork](https://fork.dev) is a Git GUI tool for Windows (and Mac) that use its own portable version of `Git for Windows`.  
-To make Fork use `git from WSL` then go to the preferences and select a custom git instance where you point it to the `git.exe` in the `wslgit\bin` folder.
+
+To make [Fork](https://fork.dev) use `git from WSL` you must have done the first optional installation step (run `install.bat`). Then go to the `Fork` preferences and select a custom git instance where you point it to the `git.exe` in the `wslgit\bin` folder (**not** the *cmd* folder!).
 
 ## Remarks
 

--- a/create-release-package.sh
+++ b/create-release-package.sh
@@ -2,14 +2,15 @@
 
 WSLGIT_BINARY=target/release/wslgit.exe
 OUTPUT_DIR=release/wslgit
+OUTPUT_CMD_DIR=$OUTPUT_DIR/cmd
 
 [[ ! -f "$WSLGIT_BINARY" ]] && echo "Release not built!" && exit 1
 
 rm -rf release/* || exit 1
-mkdir -p $OUTPUT_DIR/bin || exit 1
+mkdir -p $OUTPUT_CMD_DIR || exit 1
 
-cp "$WSLGIT_BINARY" "$OUTPUT_DIR/bin" || exit 1
-cp resources/Fork.RI "$OUTPUT_DIR/bin" || exit 1
+cp "$WSLGIT_BINARY" "$OUTPUT_CMD_DIR" || exit 1
+cp resources/Fork.RI "$OUTPUT_CMD_DIR" || exit 1
 cp resources/install.bat "$OUTPUT_DIR" || exit 1
 
 cd release && zip -r wslgit.zip ./*

--- a/create-release-package.sh
+++ b/create-release-package.sh
@@ -9,6 +9,7 @@ rm -rf release/* || exit 1
 mkdir -p $OUTPUT_DIR/bin || exit 1
 
 cp "$WSLGIT_BINARY" "$OUTPUT_DIR/bin" || exit 1
+cp resources/Fork.RI "$OUTPUT_DIR/bin" || exit 1
 cp resources/install.bat "$OUTPUT_DIR" || exit 1
 
 cd release && zip -r wslgit.zip ./*

--- a/create-release-package.sh
+++ b/create-release-package.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+WSLGIT_BINARY=target/release/wslgit.exe
+OUTPUT_DIR=release/wslgit
+
+[[ ! -f "$WSLGIT_BINARY" ]] && echo "Release not built!" && exit 1
+
+rm -rf release/* || exit 1
+mkdir -p $OUTPUT_DIR/bin || exit 1
+
+cp "$WSLGIT_BINARY" "$OUTPUT_DIR/bin" || exit 1
+cp resources/install.bat "$OUTPUT_DIR" || exit 1
+
+cd release && zip -r wslgit.zip ./*

--- a/resources/Fork.RI
+++ b/resources/Fork.RI
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Used as a proxy for calling Fork.RI.exe from WSL with the path to `git-rebase-todo`
+# converted to a windows path.
+# Expects the environment variable FORK_RI_EXE_PATH to contain the path to Fork.RI.exe.
+
+UNAME=$(uname -a)
+# 'uname -a' returns:
+# WSL1: Linux PCNAME 4.4.0-17134-Microsoft #706-Microsoft Mon Apr 01 18:13:00 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
+# MINGW64: MINGW64_NT-10.0 PCNAME 2.11.2(0.329/5/3) 2018-11-26 09:22 x86_64 Msys
+# MINGW32: MINGW32_NT-10.0 PCNAME 2.11.2(0.329/5/3) 2018-11-26 09:22 x86_64 Msys
+# MSYS: MSYS_NT-10.0 PCNAME 2.11.2(0.329/5/3) 2018-11-26 09:22 x86_64 Msys
+
+if [[ $UNAME == *Microsoft* ]]; then
+    # in a wsl shell
+    WSL_BUILD=$(sed -E 's/^.+-([0-9]+)-[Mm]icrosoft.*/\1/' <<< $UNAME)
+    if [ $WSL_BUILD -ge 17046 ] 2> /dev/null; then
+        # WSLPATH is available since WSL build 17046
+
+        # Make sure that Fork.RI.exe is executable.
+        chmod +x "$FORK_RI_EXE_PATH"
+
+        # Call Fork.RI.exe with the path to the REBASE-TODO converted to a windows path.
+        ARGS=$(wslpath -w "$@")
+        "$FORK_RI_EXE_PATH" "$ARGS"
+        exit $?
+    else
+        # ! No WSLPATH available.
+        exit 1
+    fi
+else
+    # unknown shell
+    exit 1
+fi

--- a/resources/install.bat
+++ b/resources/install.bat
@@ -1,0 +1,62 @@
+@echo off
+net session >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+   echo.
+   echo This script must be run as administrator to work properly!
+   echo Right click on the script and select "Run as administrator".
+   echo.
+   goto :error
+)
+
+set CWD=%~dp0
+set BINDIR=%CWD%bin
+cd %CWD%
+
+echo.
+if exist "%BINDIR%\git.exe" (
+    echo 'git.exe' already exist.
+) else (
+    echo Create 'git.exe' symlink...
+    mklink %BINDIR%\git.exe %BINDIR%\wslgit.exe
+    if %ERRORLEVEL% neq 0 (
+        echo ERROR! Failed to create symlink.
+        goto :error
+    )
+)
+
+echo.
+if exist "%BINDIR%\sh.exe" (
+    echo 'sh.exe' already exist.
+) else (
+    echo Create 'sh.exe' symlink...
+    mklink %BINDIR%\sh.exe C:\Windows\System32\bash.exe
+    if %ERRORLEVEL% neq 0 (
+        echo ERROR! Failed to create symlink.
+        goto :error
+    )
+)
+
+echo.
+if exist "%BINDIR%\bash.exe" (
+    echo 'bash.exe' already exist.
+) else (
+    echo Create 'bash.exe' symlink...
+    mklink %BINDIR%\bash.exe C:\Windows\System32\bash.exe
+    if %ERRORLEVEL% neq 0 (
+        echo ERROR! Failed to create symlink.
+        goto :error
+    )
+)
+
+echo.
+echo Installation successful!
+echo.
+echo Add to the Windows Path environment variable (user or system) to use as system git:
+echo  %BINDIR%
+echo.
+pause
+exit /B 0
+
+:error
+pause
+exit /B 1

--- a/resources/install.bat
+++ b/resources/install.bat
@@ -37,7 +37,7 @@ if exist "%BINDIR%\sh.exe" (
     echo 'sh.exe' already exist.
 ) else (
     echo Create 'sh.exe' symlink...
-    mklink %BINDIR%\sh.exe C:\Windows\System32\bash.exe
+    mklink %BINDIR%\sh.exe C:\Windows\System32\wsl.exe
     if %ERRORLEVEL% neq 0 (
         echo ERROR! Failed to create symlink.
         goto :error
@@ -49,7 +49,7 @@ if exist "%BINDIR%\bash.exe" (
     echo 'bash.exe' already exist.
 ) else (
     echo Create 'bash.exe' symlink...
-    mklink %BINDIR%\bash.exe C:\Windows\System32\bash.exe
+    mklink %BINDIR%\bash.exe C:\Windows\System32\wsl.exe
     if %ERRORLEVEL% neq 0 (
         echo ERROR! Failed to create symlink.
         goto :error

--- a/resources/install.bat
+++ b/resources/install.bat
@@ -10,57 +10,105 @@ if %ERRORLEVEL% neq 0 (
 
 set CWD=%~dp0
 set BINDIR=%CWD%bin
+set CMDDIR=%CWD%cmd
 cd %CWD%
 
 echo.
 echo Make sure Fork.RI is executable in WSL...
-wsl -- chmod +x bin/Fork.RI
+wsl -- chmod +x cmd/Fork.RI
 if %ERRORLEVEL% neq 0 (
     echo ERROR! Failed to make Fork.RI executable in WSL.
     goto :error
 )
+echo OK.
 
 echo.
-if exist "%BINDIR%\git.exe" (
+if exist "%CMDDIR%\git.exe" (
     echo 'git.exe' already exist.
 ) else (
     echo Create 'git.exe' symlink...
-    mklink %BINDIR%\git.exe %BINDIR%\wslgit.exe
+    mklink %CMDDIR%\git.exe %CMDDIR%\wslgit.exe
     if %ERRORLEVEL% neq 0 (
-        echo ERROR! Failed to create symlink.
+        echo ERROR! Failed to create symlink '%CMDDIR%\git.exe'.
         goto :error
+    ) else (
+        echo OK.
+    )
+)
+
+echo.
+if not exist "%BINDIR%" (
+    echo Create 'bin' directory...
+    mkdir "%BINDIR%"
+    if %ERRORLEVEL% neq 0 (
+        echo ERROR! Failed to create directory '%BINDIR%'.
+        goto :error
+    ) else (
+        echo OK.
+    )
+)
+
+echo.
+if exist "%BINDIR%\git.exe" (
+    echo 'bin\git.exe' already exist.
+) else (
+    echo Create 'bin\git.exe' symlink...
+    mklink %BINDIR%\git.exe %CMDDIR%\wslgit.exe
+    if %ERRORLEVEL% neq 0 (
+        echo ERROR! Failed to create symlink '%BINDIR%\git.exe'.
+        goto :error
+    ) else (
+        echo OK.
+    )
+)
+
+echo.
+if exist "%BINDIR%\Fork.RI" (
+    echo 'bin\Fork.RI' already exist.
+) else (
+    echo Create 'bin\Fork.RI' symlink...
+    mklink %BINDIR%\Fork.RI %CMDDIR%\Fork.RI
+    if %ERRORLEVEL% neq 0 (
+        echo ERROR! Failed to create symlink '%BINDIR%\Fork.RI'.
+        goto :error
+    ) else (
+        echo OK.
     )
 )
 
 echo.
 if exist "%BINDIR%\sh.exe" (
-    echo 'sh.exe' already exist.
+    echo 'bin\sh.exe' already exist.
 ) else (
-    echo Create 'sh.exe' symlink...
+    echo Create 'bin\sh.exe' symlink...
     mklink %BINDIR%\sh.exe C:\Windows\System32\wsl.exe
     if %ERRORLEVEL% neq 0 (
-        echo ERROR! Failed to create symlink.
+        echo ERROR! Failed to create symlink '%BINDIR%\sh.exe'.
         goto :error
+    ) else (
+        echo OK.
     )
 )
 
 echo.
 if exist "%BINDIR%\bash.exe" (
-    echo 'bash.exe' already exist.
+    echo 'bin\bash.exe' already exist.
 ) else (
-    echo Create 'bash.exe' symlink...
+    echo Create 'bin\bash.exe' symlink...
     mklink %BINDIR%\bash.exe C:\Windows\System32\wsl.exe
     if %ERRORLEVEL% neq 0 (
-        echo ERROR! Failed to create symlink.
+        echo ERROR! Failed to create symlink '%BINDIR%\bash.exe'.
         goto :error
+    ) else (
+        echo OK.
     )
 )
 
 echo.
 echo Installation successful!
 echo.
-echo Add to the Windows Path environment variable (user or system) to use as system git:
-echo  %BINDIR%
+echo (Optional) Add to the Windows Path environment variable:
+echo  %CMDDIR%
 echo.
 pause
 exit /B 0

--- a/resources/install.bat
+++ b/resources/install.bat
@@ -13,6 +13,14 @@ set BINDIR=%CWD%bin
 cd %CWD%
 
 echo.
+echo Make sure Fork.RI is executable in WSL...
+wsl -- chmod +x bin/Fork.RI
+if %ERRORLEVEL% neq 0 (
+    echo ERROR! Failed to make Fork.RI executable in WSL.
+    goto :error
+)
+
+echo.
 if exist "%BINDIR%\git.exe" (
     echo 'git.exe' already exist.
 ) else (

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -1,0 +1,104 @@
+use std::env;
+
+use wsl;
+
+/// Returns `true` if the process was invoked by `Fork.exe`.
+pub fn needs_patching() -> bool {
+    env::vars()
+        .position(|var| "FORK_PROCESS_ID" == var.0)
+        .is_some()
+}
+
+/// Patches the argument for Fork's interactive-rebase GUI.
+///
+/// If the argument is an editor and the editor is `Fork.RI.exe` then replace the
+/// argument path with the path to the `Fork.RI` script and pass the path to
+/// `Fork.RI.exe` to WSL using the `FORK_RI_EXE_PATH` environment variable.
+/// The `Fork.RI` script is executed in WSL and will call `Fork.RI.exe` with
+/// the path to `git-rebase-todo` converted to a Windows-path.
+pub fn patch_argument(arg: String) -> String {
+    lazy_static! {
+        // "xxx.editor=xxx\Fork.RI.exe"
+        static ref FORK_RI_EXE_PATH_EX: regex::Regex = regex::Regex::new(
+            r"(?P<prefix>\.editor=)(?P<fork_ri_exe_path>.*Fork\.RI\.exe)"
+        )
+        .expect("Failed to compile FORK_RI_EXE_PATH_EX regex");
+    }
+
+    match FORK_RI_EXE_PATH_EX.captures(arg.as_str()) {
+        Some(caps) => {
+            let fork_ri_exe_path = caps.name("fork_ri_exe_path").unwrap().as_str();
+            wsl::share_val("FORK_RI_EXE_PATH", fork_ri_exe_path, true);
+
+            let fork_ri_script_path = match env::current_exe() {
+                Ok(p) => p
+                    .parent()
+                    .unwrap()
+                    .join("Fork.RI")
+                    .to_string_lossy()
+                    .into_owned(),
+                Err(e) => {
+                    eprintln!("Failed to get current exe path: {}", e);
+                    panic!();
+                }
+            };
+
+            let new_editor = format!("${{prefix}}{}", fork_ri_script_path);
+            return FORK_RI_EXE_PATH_EX
+                .replace_all(arg.as_str(), new_editor.as_str())
+                .into_owned();
+        }
+        None => return arg,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invoked_by_fork() {
+        env::set_var("FORK_PROCESS_ID", "5");
+        assert_eq!(true, needs_patching());
+
+        env::remove_var("FORK_PROCESS_ID");
+        assert_eq!(false, needs_patching());
+    }
+
+    #[test]
+    fn patch_argument_for_fork() {
+        // The Fork.RI script is located in the same directory as the wslgit executable.
+        let fork_ri_script_path: String = match env::current_exe() {
+            Ok(p) => p
+                .parent()
+                .unwrap()
+                .join("Fork.RI")
+                .to_string_lossy()
+                .into_owned(),
+            Err(e) => {
+                eprintln!("Failed to get current exe path: {}", e);
+                panic!();
+            }
+        };
+
+        env::set_var("FORK_PROCESS_ID", "42");
+
+        assert_eq!(
+            patch_argument("core.editor=C:\\one\\Fork.RI.exe".to_owned()),
+            format!("core.editor={}", fork_ri_script_path)
+        );
+        assert!(env::vars()
+            .position(|var| "FORK_RI_EXE_PATH" == var.0 && "C:\\one\\Fork.RI.exe" == var.1)
+            .is_some());
+        env::remove_var("FORK_RI_EXE_PATH");
+
+        assert_eq!(
+            patch_argument("sequence.editor=C:\\two\\Fork.RI.exe".to_owned()),
+            format!("sequence.editor={}", fork_ri_script_path)
+        );
+        assert!(env::vars()
+            .position(|var| "FORK_RI_EXE_PATH" == var.0 && "C:\\two\\Fork.RI.exe" == var.1)
+            .is_some());
+        env::remove_var("FORK_RI_EXE_PATH");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,14 @@ fn quote_argument(arg: String) -> String {
     }
 }
 
+fn format_argument(arg: String) -> String {
+    let mut arg = arg;
+    arg = translate_path_to_unix(arg);
+    arg = escape_characters(arg);
+    arg = quote_argument(arg);
+    arg
+}
+
 /// Return `true` if the git command can access remotes and therefore might need
 /// the setup of an interactive shell.
 fn git_command_needs_interactive_shell() -> bool {
@@ -208,13 +216,7 @@ fn main() {
     let mut cmd_args = Vec::new();
     let mut git_args: Vec<String> = vec![String::from("git")];
 
-    git_args.extend(
-        env::args()
-            .skip(1)
-            .map(translate_path_to_unix)
-            .map(escape_characters)
-            .map(quote_argument),
-    );
+    git_args.extend(env::args().skip(1).map(format_argument));
 
     let git_cmd: String = git_args.join(" ");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,7 @@ fn invalid_characters(ch: char) -> bool {
     }
 }
 
-fn format_argument(arg: String) -> String {
+fn quote_argument(arg: String) -> String {
     if arg.contains(invalid_characters) || arg.is_empty() {
         return format!("\"{}\"", arg);
     } else {
@@ -213,7 +213,7 @@ fn main() {
             .skip(1)
             .map(translate_path_to_unix)
             .map(escape_characters)
-            .map(format_argument),
+            .map(quote_argument),
     );
 
     let git_cmd: String = git_args.join(" ");
@@ -381,46 +381,46 @@ mod tests {
     }
 
     #[test]
-    fn format_argument_with_invalid_character() {
-        assert_eq!(format_argument("abc def".to_string()), "\"abc def\"");
-        assert_eq!(format_argument("abc(def".to_string()), "\"abc(def\"");
-        assert_eq!(format_argument("abc)def".to_string()), "\"abc)def\"");
-        assert_eq!(format_argument("abc|def".to_string()), "\"abc|def\"");
+    fn quote_argument_with_invalid_character() {
+        assert_eq!(quote_argument("abc def".to_string()), "\"abc def\"");
+        assert_eq!(quote_argument("abc(def".to_string()), "\"abc(def\"");
+        assert_eq!(quote_argument("abc)def".to_string()), "\"abc)def\"");
+        assert_eq!(quote_argument("abc|def".to_string()), "\"abc|def\"");
         assert_eq!(
-            format_argument("\\\"abc def\\\"".to_string()),
+            quote_argument("\\\"abc def\\\"".to_string()),
             "\"\\\"abc def\\\"\""
         );
         assert_eq!(
-            format_argument("user.(name|email)".to_string()),
+            quote_argument("user.(name|email)".to_string()),
             "\"user.(name|email)\""
         );
     }
 
     #[test]
     fn format_long_argument_with_invalid_character() {
-        assert_eq!(format_argument("--abc def".to_string()), "\"--abc def\"");
-        assert_eq!(format_argument("--abc=def".to_string()), "--abc=def");
-        assert_eq!(format_argument("--abc=d ef".to_string()), "\"--abc=d ef\"");
-        assert_eq!(format_argument("--abc=d(ef".to_string()), "\"--abc=d(ef\"");
-        assert_eq!(format_argument("--abc=d)ef".to_string()), "\"--abc=d)ef\"");
-        assert_eq!(format_argument("--abc=d|ef".to_string()), "\"--abc=d|ef\"");
+        assert_eq!(quote_argument("--abc def".to_string()), "\"--abc def\"");
+        assert_eq!(quote_argument("--abc=def".to_string()), "--abc=def");
+        assert_eq!(quote_argument("--abc=d ef".to_string()), "\"--abc=d ef\"");
+        assert_eq!(quote_argument("--abc=d(ef".to_string()), "\"--abc=d(ef\"");
+        assert_eq!(quote_argument("--abc=d)ef".to_string()), "\"--abc=d)ef\"");
+        assert_eq!(quote_argument("--abc=d|ef".to_string()), "\"--abc=d|ef\"");
         assert_eq!(
-            format_argument("--pretty=format:a(b|c)d".to_string()),
+            quote_argument("--pretty=format:a(b|c)d".to_string()),
             "\"--pretty=format:a(b|c)d\""
         );
         assert_eq!(
-            format_argument("--pretty=format:a (b | c) d".to_string()),
+            quote_argument("--pretty=format:a (b | c) d".to_string()),
             "\"--pretty=format:a (b | c) d\""
         );
         // Long arguments with invalid characters in argument name
-        assert_eq!(format_argument("--abc(def".to_string()), "\"--abc(def\"");
-        assert_eq!(format_argument("--abc)def".to_string()), "\"--abc)def\"");
-        assert_eq!(format_argument("--abc|def".to_string()), "\"--abc|def\"");
+        assert_eq!(quote_argument("--abc(def".to_string()), "\"--abc(def\"");
+        assert_eq!(quote_argument("--abc)def".to_string()), "\"--abc)def\"");
+        assert_eq!(quote_argument("--abc|def".to_string()), "\"--abc|def\"");
     }
 
     #[test]
     fn format_empty_argument() {
-        assert_eq!(format_argument("".to_string()), "\"\"");
+        assert_eq!(quote_argument("".to_string()), "\"\"");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ extern crate lazy_static;
 extern crate regex;
 use regex::bytes::Regex;
 
+mod wsl;
+
 fn translate_path_to_unix(argument: String) -> String {
     // An absolute or UNC path must:
     // 1. Be at the beginning of the string, or after a whitespace, colon, or equal-sign.
@@ -233,22 +235,12 @@ fn main() {
         log_arguments(&cmd_args);
     }
 
+    wsl::share_val("WSLGIT", "1", false);
+
     // setup the git subprocess launched inside WSL
     let mut git_proc_setup = Command::new("wsl");
     git_proc_setup.args(&cmd_args);
 
-    git_proc_setup.env("WSLGIT", "1");
-    let wslenv = match env::var("WSLENV") {
-        Ok(wslenv) => {
-            if wslenv.is_empty() {
-                format!("WSLGIT")
-            } else {
-                format!("{}:WSLGIT", wslenv)
-            }
-        }
-        Err(_e) => format!("WSLGIT"),
-    };
-    env::set_var("WSLENV", wslenv);
     let status;
 
     // add git commands that must use translate_path_to_win

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ extern crate lazy_static;
 extern crate regex;
 use regex::bytes::Regex;
 
+mod fork;
 mod wsl;
 
 fn translate_path_to_unix(argument: String) -> String {
@@ -133,6 +134,9 @@ fn quote_argument(arg: String) -> String {
 
 fn format_argument(arg: String) -> String {
     let mut arg = arg;
+    if fork::needs_patching() {
+        arg = fork::patch_argument(arg);
+    }
     arg = translate_path_to_unix(arg);
     arg = escape_characters(arg);
     arg = quote_argument(arg);

--- a/src/wsl.rs
+++ b/src/wsl.rs
@@ -1,0 +1,83 @@
+use std::env;
+
+/// Share a value to WSL by using an environment variable and `WSLENV`.
+///
+/// * `key` - Name to use for the environment variable.
+/// * `value` - The value of the environment variable.
+/// * `translate_path` - If `true` will append `/p` to the variable name when added to `WSLENV`.
+pub fn share_val(key: &str, value: &str, translate_path: bool) {
+    env::set_var(key, value);
+
+    let wslenv_key = if translate_path {
+        format!("{}/p", key)
+    } else {
+        key.to_owned()
+    };
+
+    let wslenv = match env::var("WSLENV") {
+        Ok(original_wslenv) => {
+            // WSLENV exists, add new variable only once
+            let re: regex::Regex =
+                regex::Regex::new(format!(r"(^|:){}(/|:|$)", wslenv_key).as_str())
+                    .expect("Failed to compile regex");
+
+            if original_wslenv.is_empty() {
+                format!("{}", wslenv_key)
+            } else if re.is_match(original_wslenv.as_str()) == false {
+                format!("{}:{}", original_wslenv, wslenv_key)
+            } else {
+                // Don't add anything to WSLENV
+                original_wslenv
+            }
+        }
+        Err(_e) => {
+            // No WSLENV
+            format!("{}", wslenv_key)
+        }
+    };
+
+    env::set_var("WSLENV", wslenv);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn share_variable_to_wsl() {
+        // No WSLENV
+        env::remove_var("WSLENV");
+        share_val("VAR1", "1", false);
+        assert_eq!("1", env::var("VAR1").unwrap());
+        assert_eq!("VAR1", env::var("WSLENV").unwrap());
+
+        // Empty WSLENV
+        env::set_var("WSLENV", "");
+        share_val("VAR2", "2", false);
+        assert_eq!("2", env::var("VAR2").unwrap());
+        assert_eq!("VAR2", env::var("WSLENV").unwrap());
+
+        // Non-empty WSLENV
+        env::set_var("WSLENV", "A");
+        share_val("VAR3", "3", false);
+        assert_eq!("3", env::var("VAR3").unwrap());
+        assert_eq!("A:VAR3", env::var("WSLENV").unwrap());
+
+        // Variable exists and already in WSLENV
+        env::set_var("VAR4", "0");
+        env::set_var("WSLENV", "VAR1:VAR2:VAR3:VAR4:VAR5");
+        share_val("VAR4", "4", false);
+        assert_eq!("4", env::var("VAR4").unwrap());
+        assert_eq!("VAR1:VAR2:VAR3:VAR4:VAR5", env::var("WSLENV").unwrap());
+
+        // Variable exists and already in WSLENV but without /p flag
+        env::set_var("VAR5", "0");
+        env::set_var("WSLENV", "VAR1:VAR2:VAR3:VAR4:VAR5");
+        share_val("VAR5", "5", true);
+        assert_eq!("5", env::var("VAR5").unwrap());
+        assert_eq!(
+            "VAR1:VAR2:VAR3:VAR4:VAR5:VAR5/p",
+            env::var("WSLENV").unwrap()
+        );
+    }
+}


### PR DESCRIPTION
Hi,

This is a PR for #97, 

I've cleaned up the changes I do for the Fork patch, separating it in its own file to keep `main.rs` as clean as possible.
I understand if you think that this is out of scope for the _wslgit_ project, if so then maybe the other commits in this PR can be interesting on their own.

* The first two and the fourth commit (82645f3, 3997e63 and 264ffdf) are just some refactoring to make adding the patch cleaner. (If you decide to not accept this PR I would be really glad if you at least took these three commits.)
* The third commit (3254818) adds a script to package a release in a zip-file containing the following structure:  
  ```
  ├── wslgit
  │   ├── bin
  │   │   └── wslgit.exe
  │   └── install.bat
  ```  
  The `install.bat` script must be run as administrator and creates three symbolic links in the `wslgit\bin` folder, mimicing the `bin` folder in a `Git for Windows` installation since it is needed by one of the tools I use:
  ```
  git.exe -> wslgit.exe
  bash.exe -> C:\Windows\System32\bash.exe
  sh.exe -> C:\Windows\System32\bash.exe
  ```
* The fifth commit (f908e7a) is the patch for [Fork](https://www.fork.dev).

(If you decide to accept this PR then might I suggest that you create a develop-branch first and merge this PR into that branch instead of the master, since I have updated the README which would make the instructions not compatible with the latest release.)