### PR TITLE
Clean up Fork.RI and fix Windows short paths usage

### DIFF
--- a/resources/Fork.RI
+++ b/resources/Fork.RI
@@ -13,7 +13,7 @@ UNAME="$(uname -a)"
 
 if [[ $UNAME == *icrosoft* ]]; then
     # in a wsl shell
-    WSL_BUILD=$(cmd.exe /c "systeminfo" | grep -E -i "build [0-9]+" | sed -E 's/^.*build ([0-9]+).*$/\1/')
+    WSL_BUILD=$(cmd.exe /c "systeminfo" | grep -E -i "build [0-9]+" | sed -E 's/^.*build ([0-9]+).*$/\1/I')
     if [ -z "$WSL_BUILD" ]; then
         WSL_BUILD=0
     fi

--- a/resources/Fork.RI
+++ b/resources/Fork.RI
@@ -3,7 +3,7 @@
 # converted to a windows path.
 # Expects the environment variable FORK_RI_EXE_PATH to contain the path to Fork.RI.exe.
 
-UNAME=$(uname -a)
+UNAME="$(uname -a)"
 # 'uname -a' returns:
 # WSL1: Linux PCNAME 4.4.0-17134-Microsoft #706-Microsoft Mon Apr 01 18:13:00 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
 # WSL2: Linux DESKTOP-4P30KCU 4.19.104-microsoft-standard #1 SMP Wed Feb 19 06:37:35 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
@@ -13,12 +13,12 @@ UNAME=$(uname -a)
 
 if [[ $UNAME == *icrosoft* ]]; then
     # in a wsl shell
-    WSL_BUILD=$(sed -E 's/^.+-([0-9]+)-Microsoft.*/\1/' <<< $UNAME)
-    if [ -z $WSL_BUILD ]; then
+    WSL_BUILD=$(sed -E 's/^.+-([0-9]+)-Microsoft.*/\1/' <<< "$UNAME")
+    if [ -z "$WSL_BUILD" ]; then
         WSL_BUILD=0
     fi
 
-    if [ $WSL_BUILD -ge 17046 || ! -z $WSL_INTEROP ]; then
+    if [ $WSL_BUILD -ge 17046 ] || [ -n "$WSL_INTEROP" ]; then
         # WSLPATH is available since WSL build 17046
 
         # Make sure that Fork.RI.exe is executable.

--- a/resources/Fork.RI
+++ b/resources/Fork.RI
@@ -13,7 +13,7 @@ UNAME="$(uname -a)"
 
 if [[ $UNAME == *icrosoft* ]]; then
     # in a wsl shell
-    WSL_BUILD=$(sed -E 's/^.+-([0-9]+)-Microsoft.*/\1/' <<< "$UNAME")
+    WSL_BUILD=$(cmd.exe /c "systeminfo" | grep -E -i "build [0-9]+" | sed -E 's/^.*build ([0-9]+).*$/\1/')
     if [ -z "$WSL_BUILD" ]; then
         WSL_BUILD=0
     fi

--- a/resources/Fork.RI
+++ b/resources/Fork.RI
@@ -21,6 +21,13 @@ if [[ $UNAME == *icrosoft* ]]; then
     if [ $WSL_BUILD -ge 17046 ] || [ -n "$WSL_INTEROP" ]; then
         # WSLPATH is available since WSL build 17046
 
+        # Make sure that FORK_RI_EXE_PATH does not contain any badly escaped spaces.
+        # It can happen when using Windows' short paths inside Fork's custom git instance path
+        # Example: Fork is configured with "C:\Users\SURNAM~1\wslgit\bin\git.exe" instead of "C:\Users\Surname Lastname\wslgit\bin\git.exe"
+        # which may be a valid use case as is does not support spaces in paths.
+        # FORK_RI_EXE_PATH would contain "/mnt/c/Users/Surname/ Lastname/wslgit/bin/Fork.RI.exe" before the following sed call
+        FORK_RI_EXE_PATH="$(sed 's/\/ / /g' <<< "$FORK_RI_EXE_PATH")"
+
         # Make sure that Fork.RI.exe is executable.
         chmod +x "$FORK_RI_EXE_PATH"
 


### PR DESCRIPTION
While investigating around issue #124, I found out a lot of errors were thrown out of the Fork.RI script:
 - when using WSL2, `uname -a` does not contain the WSL build version anymore, making the current check for build 17046 or greater fail with a syntax error because of the format of the regex
 - when using Windows short paths to configure Fork's custom git instance (e.g. `C:\PROGRA~1` instead of `C:\Program Files` to avoid spaces), the `FORK_RI_EXE_PATH` could contain invalid paths as the short name translates `PROGRA~1` to `Program/ Files`, even inside a WSL environment

As such, this PR contains several changes, each one in its own commit:
 - a clean up of the Fork.RI script, to follow good practices enforced by the shellcheck tool to avoid syntax errors
 - support for WSL2 build version checks, by calling `cmd.exe` to retrieve the build version consistently (should work with WSL1 too)
 - a workaround to enable usage of Windows short paths inside Fork, making it possible to use Fork's interactive rebase tool with setups such as the one described by #124 

Several downsides can be noted:
 - using cmd.exe inside Fork.RI to get WSL build version is slower than using uname
 - the Windows short paths workaround could theoretically be avoided if Fork could run the script from a path containing spaces
 - I'm not fluent with Rust code, hence the workaround inside the shell script, I don't know if it should stay in Fork.RI or be moved inside fork.rs

As-is, this PR enables the usage of Fork's interactive rebase tool by manually editing `%localappdata%/Fork/settings.json` to change `"GitInstancePath": "C:\\Users\\Surname Lastname\\wslgit\\bin\\git.exe",` to `"GitInstancePath": "C:\\Users\\SURNAM~1\\wslgit\\bin\\git.exe",` (confirmed with the author of #124)

I'm planning on sending a support request to Fork's maintainers to ask them if it could support spaces in Fork.RI's path, enabling wslgit to work under all setups