### PR TITLE
Support for multiple WSL distros and using a wslgit default distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,27 @@ and use that tool to edit `Path`.
 You may also need to install the latest
 [*Microsoft Visual C++ Redistributable for Visual Studio 2017*](https://aka.ms/vs/15/release/vc_redist.x64.exe).
 
+## WSL distributions and file systems
+
+When accessing files on the filesystem in a WSL distribution using the UNC path
+(`\\wsl$\dist\path` or `\\wsl.localhost\dist\path`) then the distribution used
+is extracted from the path. This means that git must be setup correctly in all
+distributions that you intend to access.
+
+When accessing files on the Windows filesystem or a mapped network drive the 
+default WSL distribution is used unless the
+[`WSLGIT_DEFAULT_DIST`](#wslgit_default_dist) environment variable is set.
+
+If the default WSL distribution is of WSL2 type then it is highly recommended to
+set the `WSLGIT_DEFAULT_DIST` to the name of a WSL1 instance since WSL1 is both
+quicker at accessing the Windows filesystem and can access mapped network drives
+which WSL2 cannot.
+
+> Tip: use symlinks to map files and folders in all distributions to a common
+> directory to avoid having to maintain multiple copies, for example you can
+> link the `~/.ssh` folder in all WSL dists to the `.ssh` folder in your Windows
+> home folder.
+
 ## Usage in VSCode
 
 VSCode will find the `git` executable automatically if the two optional installation steps were taken.
@@ -104,6 +125,14 @@ the forced startup script from `BASH_ENV` contains everything you need, and
 therefore also starts bash in non-interactive mode.
 
 This feature is only available in Windows 10 builds 17063 and later.
+
+### WSLGIT_DEFAULT_DIST
+
+Set a Windows environment variable called `WSLGIT_DEFAULT_DIST` to the name of a
+WSL distribution to use instead of the WSL default distribution when accessing
+files on the Windows filesystem or from mapped network shares.
+
+> Note, to access files on a mapped network drive a WSL1 distribution must be used.
 
 ### WSLGIT
 `wslgit` set a variable called `WSLGIT` to `1` and shares it to WSL. This variable can be used in `.bashrc` to 

--- a/src/main.rs
+++ b/src/main.rs
@@ -384,7 +384,11 @@ fn main() {
     cmd_args.push(git_cmd.clone());
 
     if enable_logging() {
-        log(format!("wslgit version {}", VERSION));
+        log(format!(
+            "wslgit version {}, current_dir {}",
+            VERSION,
+            env::current_dir().unwrap().to_str().unwrap().to_string()
+        ));
         log_arguments(&cmd_args);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,6 +361,18 @@ fn main() {
 
     let git_cmd: String = git_args.join(" ");
 
+    let curr_dir = env::current_dir().unwrap();
+    // Assumes that the first element in args is the executable
+    let args: Vec<String> = env::args().skip(1).collect();
+    let working_directory = get_working_directory(curr_dir, &args);
+    match get_wsl_dist_name(&working_directory) {
+        Some(wsl_dist) => {
+            cmd_args.push("--distribution".to_string());
+            cmd_args.push(wsl_dist.to_string());
+        }
+        None => {}
+    }
+
     // build the command arguments that are passed to wsl.exe
     cmd_args.push("-e".to_string());
     cmd_args.push(BASH_EXECUTABLE.to_string());


### PR DESCRIPTION
I use WSL2 for my main distro, but unfortunately I still have to do some stuff in the windows filesystem. So I set up a WSL1 running Alpine Linux and used git from within there. But my git GUI (Fork) was still using git from WSL2.

I then figured that it must be possible for wslgit to know if working in the windows filesystem or if working in a WSL2 filesystem and use the appropriate WSL distribution. It turns out that it was quite simple to detect when accessing files in a WSL filesystem using the UNC path and also to know which distribution must be used to access those files (solving #127?), and for all other paths use the default WSL distribution or a custom "wslgit" default distribution.