### PR TITLE
Escape `<`, `>` and `!` characters in arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,11 @@ fn translate_path_to_win(line: &[u8]) -> Vec<u8> {
 }
 
 fn escape_characters(arg: String) -> String {
-    arg.replace("\n", "$'\n'").replace("\"", "\\\"")
+    arg.replace("\n", "$'\n'")
+        .replace("\"", "\\\"")
+        .replace("<", "\\<")
+        .replace(">", "\\>")
+        .replace("!", "\\!")
 }
 
 fn invalid_characters(ch: char) -> bool {
@@ -515,6 +519,10 @@ mod tests {
         assert_eq!(
             super::escape_characters("ab\ncd ef".to_string()),
             "ab$\'\n\'cd ef"
+        );
+        assert_eq!(
+            super::escape_characters("--pretty=format:%H±.%aN±.%aE±.%at±.%cN±.%cE±.%ct±.%P±.%B<!--RevisionMessageEnd-->".to_string()),
+            "--pretty=format:%H±.%aN±.%aE±.%at±.%cN±.%cE±.%ct±.%P±.%B\\<\\!--RevisionMessageEnd--\\>"
         );
         // Long arguments with newlines...
         assert_eq!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -84,6 +84,14 @@ mod integration {
     fn long_argument_with_invalid_characters_and_spaces() {
         Command::cargo_bin(env!("CARGO_PKG_NAME"))
             .unwrap()
+            .args(&["log", "-n1", "--pretty=format:<!--RevisionMessageEnd-->"])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success()
+            .stdout("<!--RevisionMessageEnd-->");
+
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
             .args(&["log", "-n1", "--pretty=format:a ( b | c )"])
             .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
             .assert()


### PR DESCRIPTION
Fixes Issue with bash not showing the commit details in Fork #134