### PR TITLE
Make it possible to use wslgit in mixed (WSL/non-WSL) environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ distributions that you intend to access.
 
 When accessing files on the Windows filesystem or a mapped network drive the 
 default WSL distribution is used unless the
-[`WSLGIT_DEFAULT_DIST`](#wslgit_default_dist) environment variable is set. Alternatively, you can set the [`WSLGIT_WINDOWS_GIT`](#wslgit-windows-git) environment variable to completely bypass WSL in these cases instead.
+[`WSLGIT_DEFAULT_DIST`](#wslgit_default_dist) environment variable is set. Alternatively, you can set the [`WSLGIT_WINDOWS_GIT`](#wslgit_windows_git) environment variable to completely bypass WSL in these cases instead.
 
 If the default WSL distribution is of WSL2 type then it is highly recommended to
 set the `WSLGIT_DEFAULT_DIST` to the name of a WSL1 instance since WSL1 is both

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ distributions that you intend to access.
 
 When accessing files on the Windows filesystem or a mapped network drive the 
 default WSL distribution is used unless the
-[`WSLGIT_DEFAULT_DIST`](#wslgit_default_dist) environment variable is set.
+[`WSLGIT_DEFAULT_DIST`](#wslgit_default_dist) environment variable is set. Alternatively, you can set the [`WSLGIT_WINDOWS_GIT`](#wslgit-windows-git) environment variable to completely bypass WSL in these cases instead.
 
 If the default WSL distribution is of WSL2 type then it is highly recommended to
 set the `WSLGIT_DEFAULT_DIST` to the name of a WSL1 instance since WSL1 is both
@@ -133,6 +133,14 @@ WSL distribution to use instead of the WSL default distribution when accessing
 files on the Windows filesystem or from mapped network shares.
 
 > Note, to access files on a mapped network drive a WSL1 distribution must be used.
+
+### WSLGIT_WINDOWS_GIT
+
+To completely bypass WSL for repositories on the Windows filesystem and instead directly run the Windows Git executable, set a Windows environment variable called `WSLGIT_WINDOWS_GIT` to the path of that executable (usually `C:\Program Files\Git\bin\git.exe`). This can be useful (or even required) for several reasons:
+
+* In mixed environments, where some git repositories are located in WSL but others are located on the Windows filesystem, especially when you want separate `.gitconfig` files between WSL and Windows.
+* As an optimization, to skip the overhead of translating to WSL and running git in WSL.
+* This is required when you want to use TortoiseGit both for repositories in WSL and on the Windows filesystem, by pointing the **Git.exe Path** in TortoiseGit settings to `wslgit\bin`. TortoiseGit doesn't support using the WSL Git executable (`usr\bin\git`) for repositories on the Windows filesystem.
 
 ### WSLGIT
 `wslgit` set a variable called `WSLGIT` to `1` and shares it to WSL. This variable can be used in `.bashrc` to 

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,21 +386,21 @@ fn main() {
             if enable_logging() {
                 log("no distribution found".to_owned());
             }
-            if let Ok(default_git) = env::var("WSLGIT_DEFAULT_GIT") {
+            if let Ok(windows_git) = env::var("WSLGIT_WINDOWS_GIT") {
                 let status;
-                let mut default_git_proc_setup = Command::new(default_git.clone());
+                let mut windows_git_proc_setup = Command::new(windows_git.clone());
                 
-                default_git_proc_setup.args(&args);
+                windows_git_proc_setup.args(&args);
                 
                 if enable_logging() {
-                    log(format!("running default git {}", default_git));
+                    log(format!("running Windows git {}", windows_git));
                     log_arguments(&args);
                 }
                 
-                status = default_git_proc_setup
+                status = windows_git_proc_setup
                     .status()
                     .expect(&format!("Failed to execute command '{}' {:?}",
-                        &default_git,
+                        &windows_git,
                         args));
 
                 // forward any exit code

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,6 +359,14 @@ fn log(message: String) {
 }
 
 fn main() {
+    if enable_logging() {
+        log(format!(
+            "wslgit version {}, current_dir {}",
+            VERSION,
+            env::current_dir().unwrap().to_str().unwrap().to_string()
+        ));
+    }
+
     let mut cmd_args = Vec::new();
     let mut git_args: Vec<String> = vec![String::from("git")];
     git_args.extend(env::args().skip(1).map(format_argument));
@@ -374,7 +382,33 @@ fn main() {
             cmd_args.push("--distribution".to_string());
             cmd_args.push(wsl_dist.to_string());
         }
-        None => {}
+        None => {
+            if enable_logging() {
+                log("no distribution found".to_owned());
+            }
+            if let Ok(default_git) = env::var("WSLGIT_DEFAULT_GIT") {
+                let status;
+                let mut default_git_proc_setup = Command::new(default_git.clone());
+                
+                default_git_proc_setup.args(&args);
+                
+                if enable_logging() {
+                    log(format!("running default git {}", default_git));
+                    log_arguments(&args);
+                }
+                
+                status = default_git_proc_setup
+                    .status()
+                    .expect(&format!("Failed to execute command '{}' {:?}",
+                        &default_git,
+                        args));
+
+                // forward any exit code
+                if let Some(exit_code) = status.code() {
+                    std::process::exit(exit_code);
+                }
+            }
+        }
     }
 
     // build the command arguments that are passed to wsl.exe
@@ -388,11 +422,6 @@ fn main() {
     cmd_args.push(git_cmd.clone());
 
     if enable_logging() {
-        log(format!(
-            "wslgit version {}, current_dir {}",
-            VERSION,
-            env::current_dir().unwrap().to_str().unwrap().to_string()
-        ));
         log_arguments(&cmd_args);
     }
 


### PR DESCRIPTION
Currently, when running wslgit in a path that is not part of the WSL filesystem (outside of `\\wsl.localhost`), wslgit will evidently not be able to determine the WSL distribution and will just run `wsl.exe` with the default distribution.

This poses a problem when trying to use wslgit in mixed environments, where some git repositories are located in WSL but others are located in the native filesystem. For the repositories in the native filesystem, wslgit should completely bypass WSL and directly run the Windows Git executable. An example of such a mixed setup is when you want to use TortoiseGit for both types of repositories and hence point the **Git.exe Path** in TortoiseGit settings to `wslgit\bin`.

The proposed solution is to add support for a new environment variable, `WSLGIT_DEFAULT_GIT`. When this variable is set and contains the path to the Windows Git executable (usually `C:\Program Files\Git\bin\git.exe`), wslgit will run this executable for repositories outside of the WSL filesystem. This pull requests implements that solution.