### PR TITLE
Bugfix/allow dollar symbol in filenames

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -160,11 +160,20 @@ fn translate_path_to_win(line: &[u8]) -> Vec<u8> {
 }
 
 fn escape_characters(arg: String) -> String {
-    arg.replace("\n", "$'\n'")
+    // First, replace newlines with a temporary placeholder to avoid escaping the $ in $'\n'
+    let temp_newline_placeholder = "___NEWLINE_PLACEHOLDER___";
+    let arg = arg.replace("\n", temp_newline_placeholder);
+    
+    // Now escape other characters including $
+    let arg = arg
+        .replace("$", "\\$")
         .replace("\"", "\\\"")
         .replace("<", "\\<")
         .replace(">", "\\>")
-        .replace("!", "\\!")
+        .replace("!", "\\!");
+    
+    // Finally, replace the placeholder with the bash $'\n' construct
+    arg.replace(temp_newline_placeholder, "$'\n'")
 }
 
 fn invalid_characters(ch: char) -> bool {
@@ -536,6 +545,15 @@ mod tests {
         assert_eq!(
             super::escape_characters("ab\"cd ef\"".to_string()),
             "ab\\\"cd ef\\\""
+        );
+        // Test dollar sign escaping
+        assert_eq!(
+            super::escape_characters("$id.tsx".to_string()),
+            "\\$id.tsx"
+        );
+        assert_eq!(
+            super::escape_characters("file$with$multiple$dollars.txt".to_string()),
+            "file\\$with\\$multiple\\$dollars.txt"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -555,6 +555,15 @@ mod tests {
             super::escape_characters("file$with$multiple$dollars.txt".to_string()),
             "file\\$with\\$multiple\\$dollars.txt"
         );
+        // Test combination of dollar signs and newlines
+        assert_eq!(
+            super::escape_characters("$id\nvalue".to_string()),
+            "\\$id$\'\n\'value"
+        );
+        assert_eq!(
+            super::escape_characters("before$var\nafter$another".to_string()),
+            "before\\$var$\'\n\'after\\$another"
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -296,4 +296,15 @@ mod integration {
             .success()
             .stdout(predicate::str::contains("/bin/bash"));
     }
+
+    #[test]
+    fn filename_with_dollar_sign() {
+        // Test for files with $ characters like $id.tsx
+        Command::cargo_bin(env!("CARGO_PKG_NAME"))
+            .unwrap()
+            .args(&["status", "--", "$id.tsx"])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .assert()
+            .success();
+    }
 }


### PR DESCRIPTION
Fix issue where filenames with a dollar symbol (`$`) were being expanded in WSL causing them to be interpreted as ampty filename.

I am not a Rust dev, so I used CoPilot with Claude Sonnet 4 to make an attempt at a fix. Hopefully this is either the correct fix or a good starting point at something better

Fixes https://github.com/andy-5/wslgit/issues/145