### PR TITLE
Avoid systeminfo when launching Fork's rebase editor

### DIFF
--- a/resources/Fork.RI
+++ b/resources/Fork.RI
@@ -11,7 +11,7 @@ UNAME="$(uname -a)"
 # MINGW32: MINGW32_NT-10.0 PCNAME 2.11.2(0.329/5/3) 2018-11-26 09:22 x86_64 Msys
 # MSYS: MSYS_NT-10.0 PCNAME 2.11.2(0.329/5/3) 2018-11-26 09:22 x86_64 Msys
 
-if [[ $UNAME == *icrosoft* ]]; then
+if [[ -n ${WSL_INTEROP:-} || $UNAME == *icrosoft* ]]; then
     # in a wsl shell
     if ! command -v wslpath >/dev/null 2>&1; then
         exit 1

--- a/resources/Fork.RI
+++ b/resources/Fork.RI
@@ -13,32 +13,28 @@ UNAME="$(uname -a)"
 
 if [[ $UNAME == *icrosoft* ]]; then
     # in a wsl shell
-    WSL_BUILD=$(cmd.exe /c "systeminfo" | grep -E -i "build [0-9]+" | sed -E 's/^.*build ([0-9]+).*$/\1/I')
-    if [ -z "$WSL_BUILD" ]; then
-        WSL_BUILD=0
-    fi
-
-    if [ $WSL_BUILD -ge 17046 ] || [ -n "$WSL_INTEROP" ]; then
-        # WSLPATH is available since WSL build 17046
-
-        # Make sure that FORK_RI_EXE_PATH does not contain any badly escaped spaces.
-        # It can happen when using Windows' short paths inside Fork's custom git instance path
-        # Example: Fork is configured with "C:\Users\SURNAM~1\wslgit\bin\git.exe" instead of "C:\Users\Surname Lastname\wslgit\bin\git.exe"
-        # which may be a valid use case as is does not support spaces in paths.
-        # FORK_RI_EXE_PATH would contain "/mnt/c/Users/Surname/ Lastname/wslgit/bin/Fork.RI.exe" before the following sed call
-        FORK_RI_EXE_PATH="$(sed 's/\/ / /g' <<< "$FORK_RI_EXE_PATH")"
-
-        # Make sure that Fork.RI.exe is executable.
-        chmod +x "$FORK_RI_EXE_PATH"
-
-        # Call Fork.RI.exe with the path to the REBASE-TODO converted to a windows path.
-        ARGS=$(wslpath -w "$@")
-        "$FORK_RI_EXE_PATH" "$ARGS"
-        exit $?
-    else
-        # ! No WSLPATH available.
+    if ! command -v wslpath >/dev/null 2>&1; then
         exit 1
     fi
+
+    if [[ -z ${FORK_RI_EXE_PATH:-} ]] || [[ $# -ne 1 ]]; then
+        exit 2
+    fi
+
+    # Make sure that FORK_RI_EXE_PATH does not contain any badly escaped spaces.
+    # It can happen when using Windows' short paths inside Fork's custom git instance path
+    # Example: Fork is configured with "C:\Users\SURNAM~1\wslgit\bin\git.exe" instead of "C:\Users\Surname Lastname\wslgit\bin\git.exe"
+    # which may be a valid use case as is does not support spaces in paths.
+    # FORK_RI_EXE_PATH would contain "/mnt/c/Users/Surname/ Lastname/wslgit/bin/Fork.RI.exe" before the following sed call
+    FORK_RI_EXE_PATH="$(sed 's/\/ / /g' <<< "$FORK_RI_EXE_PATH")"
+
+    # Make sure that Fork.RI.exe is executable.
+    chmod +x "$FORK_RI_EXE_PATH" || exit $?
+
+    # Call Fork.RI.exe with the path to the REBASE-TODO converted to a windows path.
+    ARGS=$(wslpath -w -- "$1") || exit $?
+    "$FORK_RI_EXE_PATH" "$ARGS"
+    exit $?
 else
     # unknown shell
     exit 1

--- a/tests/fork-ri.sh
+++ b/tests/fork-ri.sh
@@ -5,7 +5,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 fork_ri=resources/Fork.RI
 
 uname() {
-    printf 'Linux test 6.6.0-microsoft-standard-WSL2 x86_64 GNU/Linux\n'
+    printf '%s\n' "${MOCK_UNAME:-Linux test 6.6.0-microsoft-standard-WSL2 x86_64 GNU/Linux}"
 }
 
 cmd.exe() {
@@ -49,6 +49,25 @@ if [[ $status -ne 0 ]]; then
 fi
 if [[ $output != 'editor:C:\repo\git-rebase-todo' ]]; then
     printf 'Unexpected Fork.RI output:\n%s\n' "$output" >&2
+    exit 1
+fi
+
+set +e
+output=$(
+    MOCK_UNAME='Linux test 6.18.38-custom-WSL2 x86_64 GNU/Linux' \
+        WSL_INTEROP=/run/WSL/1_interop \
+        FORK_RI_EXE_PATH=fork_ri_editor \
+        bash "$fork_ri" '/tmp/rebase todo' 2>&1
+)
+status=$?
+set -e
+
+if [[ $status -ne 0 ]]; then
+    printf 'Fork.RI rejected a custom WSL kernel with status %d:\n%s\n' "$status" "$output" >&2
+    exit 1
+fi
+if [[ $output != 'editor:C:\repo\git-rebase-todo' ]]; then
+    printf 'Unexpected custom-kernel Fork.RI output:\n%s\n' "$output" >&2
     exit 1
 fi
 

--- a/tests/fork-ri.sh
+++ b/tests/fork-ri.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+fork_ri=resources/Fork.RI
+
+uname() {
+    printf 'Linux test 6.6.0-microsoft-standard-WSL2 x86_64 GNU/Linux\n'
+}
+
+cmd.exe() {
+    printf 'unexpected cmd.exe invocation\n' >&2
+    return 99
+}
+
+chmod() {
+    return 0
+}
+
+wslpath() {
+    if [[ ${MOCK_WSLPATH_FAIL:-0} == 1 ]]; then
+        return 23
+    fi
+    if [[ $# -ne 3 || $1 != -w || $2 != -- || $3 != '/tmp/rebase todo' ]]; then
+        printf 'unexpected wslpath arguments: %q\n' "$*" >&2
+        return 22
+    fi
+    printf 'C:\\repo\\git-rebase-todo\n'
+}
+
+fork_ri_editor() {
+    printf 'editor:%s\n' "$1"
+}
+
+export -f uname cmd.exe chmod wslpath fork_ri_editor
+
+set +e
+output=$(
+    WSL_INTEROP=/run/WSL/1_interop \
+        FORK_RI_EXE_PATH=fork_ri_editor \
+        bash "$fork_ri" '/tmp/rebase todo' 2>&1
+)
+status=$?
+set -e
+
+if [[ $status -ne 0 ]]; then
+    printf 'Fork.RI exited with %d:\n%s\n' "$status" "$output" >&2
+    exit 1
+fi
+if [[ $output != 'editor:C:\repo\git-rebase-todo' ]]; then
+    printf 'Unexpected Fork.RI output:\n%s\n' "$output" >&2
+    exit 1
+fi
+
+set +e
+output=$(
+    WSL_INTEROP=/run/WSL/1_interop \
+        FORK_RI_EXE_PATH=fork_ri_editor \
+        MOCK_WSLPATH_FAIL=1 \
+        bash "$fork_ri" '/tmp/rebase todo' 2>&1
+)
+status=$?
+set -e
+
+if [[ $status -ne 23 ]]; then
+    printf 'Expected wslpath status 23, got %d:\n%s\n' "$status" "$output" >&2
+    exit 1
+fi
+if [[ $output == *editor:* ]]; then
+    printf 'Editor ran after wslpath failed:\n%s\n' "$output" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Detect `wslpath` directly instead of starting `cmd.exe /c systeminfo`.
- Detect WSL through `WSL_INTEROP`, with the historical kernel-name check as
  a fallback for older environments.
- Validate the editor path and rebase-todo argument before conversion.
- Propagate `chmod` and `wslpath` failures instead of launching the editor
  with an invalid path.
- Add shell regressions for conversion, failure propagation, and custom WSL
  kernels whose `uname` output omits Microsoft.

## Problem

`Fork.RI` only needs WSL interoperability and `wslpath`, but it previously
started a Windows `systeminfo` scan and parsed the Windows build number before
every interactive rebase.

That indirect probe adds an unnecessary Windows process to a latency-sensitive
editor path. A kernel-name-only replacement is also insufficient because
custom WSL kernels can omit Microsoft from `uname` while interoperability is
fully available.

Using `WSL_INTEROP` for environment detection and checking `wslpath` directly
tests the capabilities that the script actually needs.

## Verification

- [x] `bash -n resources/Fork.RI tests/fork-ri.sh`
- [x] `shellcheck resources/Fork.RI tests/fork-ri.sh`
- [x] `bash tests/fork-ri.sh`
- [x] Host smoke test on a custom WSL kernel whose `uname` output omits
      Microsoft
- [x] `git diff --check develop...HEAD`
- [ ] Start an interactive rebase from Fork and confirm the rebase-todo editor
      opens without invoking `cmd.exe /c systeminfo`

## Compatibility

The existing `FORK_RI_EXE_PATH` normalization and Windows-path conversion
remain in place. The script still launches the configured `Fork.RI.exe` with a
single converted rebase-todo path.

`WSL_INTEROP` is preferred when present. The historical Microsoft kernel-name
match remains as a fallback. Missing `wslpath` retains
exit status 1, while missing editor configuration or an invalid argument count
returns exit status 2.

## Related issues

Related to #153. This removes the `cmd.exe /c systeminfo` invocation reported
there, but it does not claim to resolve unrelated failures while launching the
Windows editor executable itself.
