### PR TITLE
Detect installer command failures at execution time

### DIFF
--- a/resources/install.bat
+++ b/resources/install.bat
@@ -1,6 +1,6 @@
 @echo off
 net session >nul 2>&1
-if %ERRORLEVEL% neq 0 (
+if errorlevel 1 (
    echo.
    echo This script must be run as administrator to work properly!
    echo Right click on the script and select "Run as administrator".
@@ -19,7 +19,7 @@ if exist "%CMDDIR%\git.exe" (
 ) else (
     echo Create 'git.exe' symlink...
     mklink "%CMDDIR%\git.exe" "%CMDDIR%\wslgit.exe"
-    if %ERRORLEVEL% neq 0 (
+    if errorlevel 1 (
         echo ERROR! Failed to create symlink '%CMDDIR%\git.exe'.
         goto :error
     ) else (
@@ -31,7 +31,7 @@ echo.
 if not exist "%BINDIR%" (
     echo Create 'bin' directory...
     mkdir "%BINDIR%"
-    if %ERRORLEVEL% neq 0 (
+    if errorlevel 1 (
         echo ERROR! Failed to create directory '%BINDIR%'.
         goto :error
     ) else (
@@ -45,7 +45,7 @@ if exist "%BINDIR%\git.exe" (
 ) else (
     echo Create 'bin\git.exe' symlink...
     mklink "%BINDIR%\git.exe" "%CMDDIR%\wslgit.exe"
-    if %ERRORLEVEL% neq 0 (
+    if errorlevel 1 (
         echo ERROR! Failed to create symlink '%BINDIR%\git.exe'.
         goto :error
     ) else (
@@ -59,7 +59,7 @@ if exist "%BINDIR%\Fork.RI" (
 ) else (
     echo Create 'bin\Fork.RI' symlink...
     mklink "%BINDIR%\Fork.RI" "%CMDDIR%\Fork.RI"
-    if %ERRORLEVEL% neq 0 (
+    if errorlevel 1 (
         echo ERROR! Failed to create symlink '%BINDIR%\Fork.RI'.
         goto :error
     ) else (
@@ -73,7 +73,7 @@ if exist "%BINDIR%\sh.exe" (
 ) else (
     echo Create 'bin\sh.exe' symlink...
     mklink "%BINDIR%\sh.exe" "C:\Windows\System32\wsl.exe"
-    if %ERRORLEVEL% neq 0 (
+    if errorlevel 1 (
         echo ERROR! Failed to create symlink '%BINDIR%\sh.exe'.
         goto :error
     ) else (
@@ -87,7 +87,7 @@ if exist "%BINDIR%\bash.exe" (
 ) else (
     echo Create 'bin\bash.exe' symlink...
     mklink "%BINDIR%\bash.exe" "C:\Windows\System32\wsl.exe"
-    if %ERRORLEVEL% neq 0 (
+    if errorlevel 1 (
         echo ERROR! Failed to create symlink '%BINDIR%\bash.exe'.
         goto :error
     ) else (


### PR DESCRIPTION
## Summary

- Replace all seven `%ERRORLEVEL%` comparisons with the runtime
  `if errorlevel 1` form.
- Ensure failures from `mkdir` and `mklink` are observed immediately
  and routed through the installer's existing error path.
- Use the same error-checking idiom for the initial administrator check.

## Root cause

`cmd.exe` expands `%ERRORLEVEL%` when it parses a parenthesized command
block. Six installer checks are inside `if`/`else` blocks, so they can
read the status from before the preceding `mkdir` or `mklink` command
runs. This can report `OK` and continue after an operation failed.

`if errorlevel 1` evaluates the current command status when that
statement executes, so the check observes the operation immediately
before it.

## Verification

- [x] Reproduced the parsing behavior with Windows `cmd.exe`: after a
      command returned exit status 7, the `%ERRORLEVEL%` form printed
      `old-missed`, while `if errorlevel 1` printed `new-detected`.
- [x] `git diff --check develop...HEAD`
- [x] Confirmed all seven checks use `if errorlevel 1` and no
      `%ERRORLEVEL%` checks remain.
- [x] Confirmed `resources/install.bat` retains CRLF line endings.
- [ ] Run the installer from an elevated Windows Command Prompt in a
      disposable installation directory.

## Compatibility

- Installation paths, link targets, command ordering, and user-facing
  messages are unchanged.
- The existing success and `:error` control-flow paths are unchanged.
- The replacement uses standard `cmd.exe` syntax and does not require
  delayed environment-variable expansion.
- The top-level administrator check was not affected by block expansion,
  but now uses the same error-checking form as the remaining installer.
