### PR TITLE
Forward Fork AskPass variables through WSL

### DIFF
--- a/src/fork.rs
+++ b/src/fork.rs
@@ -9,6 +9,20 @@ pub fn needs_patching() -> bool {
         .is_some()
 }
 
+/// Share the environment Fork uses for Git credential prompts with WSL.
+pub fn share_environment() {
+    if !needs_patching() {
+        return;
+    }
+
+    for key in &["FORK_PROCESS_ID", "SSH_ASKPASS_REQUIRE", "NO_PROMPT"] {
+        wsl::share_env(key, false);
+    }
+    for key in &["FORK_REPOSITORY_PATH", "SSH_ASKPASS"] {
+        wsl::share_env(key, true);
+    }
+}
+
 /// Patches the argument for Fork's interactive-rebase GUI.
 ///
 /// If the argument is an editor and the editor is `Fork.RI.exe` then replace the

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,6 +464,7 @@ fn main() {
         log_arguments(&cmd_args);
     }
 
+    fork::share_environment();
     wsl::share_val("WSLGIT", "1", false);
 
     // setup the git subprocess launched inside WSL

--- a/src/wsl.rs
+++ b/src/wsl.rs
@@ -1,5 +1,35 @@
 use std::env;
 
+fn share_key(key: &str, translate_path: bool) {
+    let wslenv_key = if translate_path {
+        format!("{}/p", key)
+    } else {
+        key.to_owned()
+    };
+
+    let original_wslenv = env::var("WSLENV").unwrap_or_default();
+    let mut entries = Vec::new();
+    let mut key_added = false;
+
+    for entry in original_wslenv.split(':').filter(|entry| !entry.is_empty()) {
+        let entry_key = entry.split('/').next().unwrap();
+        if entry_key.eq_ignore_ascii_case(key) {
+            if !key_added {
+                entries.push(wslenv_key.clone());
+                key_added = true;
+            }
+        } else {
+            entries.push(entry.to_owned());
+        }
+    }
+
+    if !key_added {
+        entries.push(wslenv_key);
+    }
+
+    env::set_var("WSLENV", entries.join(":"));
+}
+
 /// Share a value to WSL by using an environment variable and `WSLENV`.
 ///
 /// * `key` - Name to use for the environment variable.
@@ -7,36 +37,14 @@ use std::env;
 /// * `translate_path` - If `true` will append `/p` to the variable name when added to `WSLENV`.
 pub fn share_val(key: &str, value: &str, translate_path: bool) {
     env::set_var(key, value);
+    share_key(key, translate_path);
+}
 
-    let wslenv_key = if translate_path {
-        format!("{}/p", key)
-    } else {
-        key.to_owned()
-    };
-
-    let wslenv = match env::var("WSLENV") {
-        Ok(original_wslenv) => {
-            // WSLENV exists, add new variable only once
-            let re: regex::Regex =
-                regex::Regex::new(format!(r"(^|:){}(/|:|$)", wslenv_key).as_str())
-                    .expect("Failed to compile regex");
-
-            if original_wslenv.is_empty() {
-                format!("{}", wslenv_key)
-            } else if re.is_match(original_wslenv.as_str()) == false {
-                format!("{}:{}", original_wslenv, wslenv_key)
-            } else {
-                // Don't add anything to WSLENV
-                original_wslenv
-            }
-        }
-        Err(_e) => {
-            // No WSLENV
-            format!("{}", wslenv_key)
-        }
-    };
-
-    env::set_var("WSLENV", wslenv);
+/// Share an existing environment variable with WSL when it is present.
+pub fn share_env(key: &str, translate_path: bool) {
+    if env::var_os(key).is_some() {
+        share_key(key, translate_path);
+    }
 }
 
 #[cfg(test)]
@@ -75,9 +83,6 @@ mod tests {
         env::set_var("WSLENV", "VAR1:VAR2:VAR3:VAR4:VAR5");
         share_val("VAR5", "5", true);
         assert_eq!("5", env::var("VAR5").unwrap());
-        assert_eq!(
-            "VAR1:VAR2:VAR3:VAR4:VAR5:VAR5/p",
-            env::var("WSLENV").unwrap()
-        );
+        assert_eq!("VAR1:VAR2:VAR3:VAR4:VAR5/p", env::var("WSLENV").unwrap());
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -266,6 +266,35 @@ mod integration {
     }
 
     #[test]
+    fn fork_askpass_environment_is_forwarded_to_wsl() {
+        Command::new(cargo_bin!(env!("CARGO_PKG_NAME")))
+            .args(&[
+                "log",
+                "-1",
+                "--pretty=format:$(printenv FORK_PROCESS_ID FORK_REPOSITORY_PATH SSH_ASKPASS SSH_ASKPASS_REQUIRE NO_PROMPT WSLENV)",
+            ])
+            .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+            .env("WSLENV", "EXISTING:SSH_ASKPASS")
+            .env("EXISTING", "preserved")
+            .env("FORK_PROCESS_ID", "fork-process")
+            .env("FORK_REPOSITORY_PATH", r"C:\fork repo")
+            .env("SSH_ASKPASS", r"C:\Fork\askpass.exe")
+            .env("SSH_ASKPASS_REQUIRE", "force")
+            .env("NO_PROMPT", "1")
+            .assert()
+            .success()
+            .stdout(concat!(
+                "fork-process\n",
+                "/mnt/c/fork repo\n",
+                "/mnt/c/Fork/askpass.exe\n",
+                "force\n",
+                "1\n",
+                "EXISTING:SSH_ASKPASS/p:FORK_PROCESS_ID:SSH_ASKPASS_REQUIRE:",
+                "NO_PROMPT:FORK_REPOSITORY_PATH/p:WSLGIT",
+            ));
+    }
+
+    #[test]
     fn shell_environment_variable() {
         Command::new(cargo_bin!(env!("CARGO_PKG_NAME")))
             // Use pretty format to call 'printenv SHELL'


### PR DESCRIPTION
## Summary

- Forward Fork's credential-prompt environment into WSL when wslgit is
  invoked by Fork.
- Apply WSL path translation only to variables containing Windows paths.
- Preserve unrelated `WSLENV` entries while normalizing existing entries
  for the forwarded variables.

## Problem

Fork can invoke wslgit with an AskPass executable configured while wslgit
runs Git inside WSL. Existing Windows process variables are not imported by
WSL unless they are registered in `WSLENV`, and Windows path values also need
WSL's `/p` translation flag.

As a result, Git and its credential-prompt process cannot reliably consume
Fork's existing AskPass and repository context inside WSL.

## Implementation

Forward only this allowlist when `FORK_PROCESS_ID` indicates that wslgit was
started by Fork:

- `FORK_PROCESS_ID`
- `SSH_ASKPASS_REQUIRE`
- `NO_PROMPT`
- `FORK_REPOSITORY_PATH`
- `SSH_ASKPASS`

`FORK_REPOSITORY_PATH` and `SSH_ASKPASS` are registered with the `WSLENV`
`/p` flag because they contain Windows paths. The other three variables are
forwarded without path translation.

Only variables already present in the process environment are registered.
Existing entries for the same key are matched case-insensitively and
normalized to one entry with the required flags. Unrelated `WSLENV` entries
remain in their original order.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check develop...HEAD`
- [x] Focused AskPass integration test: 1 passed, 0 failed.
- [x] Focused `WSLENV` normalization unit test: 1 passed, 0 failed.
- [x] Windows-target suite excluding the environment-specific upstream
      `shell_environment_variable` test: 32 passed, 0 failed, 1 filtered.
- [x] Gitleaks history scan: no leaks found.
- [ ] Exercise Fork's real credential dialog through wslgit.

The excluded upstream test expects the inherited `SHELL` value to contain
`/bin/bash`; this environment supplies `/usr/bin/zsh`. The test is unchanged
and fails on this branch for that reason. Strict Clippy is also blocked by 28
warnings in unchanged upstream lines; the new lines were not among the
reported locations.

## Compatibility

- Invocations outside Fork are unchanged.
- Missing Fork variables are not added to `WSLENV`.
- No arbitrary process variables are forwarded.
- Existing unrelated `WSLENV` entries are preserved.
- This does not modify Fork's executable, Git credential-helper
  configuration, or the AskPass executable itself.

## Related issues

Related to #151.

That report also contains an invalid-handle error and WSL startup diagnostics.
This change only addresses Fork credential-prompt environment forwarding and
does not claim to resolve those separate failure modes.
