### PR TITLE
Avoid a second WSL launch for common path output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,9 @@ lazy_static = "1.5"
 assert_cmd = "2.1.1"
 predicates = "3.1.3"
 
+[[bench]]
+name = "benchmark"
+harness = false
+
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ cargo test -- --test-threads=1
 cargo test test -- --test-threads=1
 # Run only integration tests
 cargo test integration -- --test-threads=1
-# Run benchmarks (requires nightly toolchain!)
-cargo +nightly bench
+# Run benchmarks on stable Rust
+cargo bench --target x86_64-pc-windows-gnu --bench benchmark
+# Override the default 10 measured iterations
+cargo bench --target x86_64-pc-windows-gnu --bench benchmark -- --iterations 25
 ```

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,60 +1,103 @@
-#![feature(test)]
-extern crate test;
+use std::env;
+use std::hint::black_box;
+use std::process::Command;
+use std::time::{Duration, Instant};
 
-#[cfg(test)]
-mod bench {
-    use std::env;
-    use std::process::Command;
-    use test::Bencher;
+const WSLGIT: &str = env!("CARGO_BIN_EXE_wslgit");
+const WARMUP_ITERATIONS: usize = 2;
+const DEFAULT_ITERATIONS: usize = 10;
 
-    #[bench]
-    fn no_translation(b: &mut Bencher) {
-        b.iter(|| {
-            Command::new("wslgit")
-                .args(&["--version"])
-                .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
-                .output()
-        })
+fn run(args: &[&str]) {
+    let output = Command::new(WSLGIT)
+        .args(args)
+        .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
+        .output()
+        .unwrap_or_else(|error| panic!("failed to start benchmark command: {}", error));
+
+    assert!(
+        output.status.success(),
+        "benchmark command exited with {}",
+        output.status
+    );
+    assert!(
+        !output.stdout.is_empty(),
+        "benchmark command produced no output"
+    );
+    black_box(output);
+}
+
+fn benchmark(name: &str, iterations: usize, args: &[&str]) {
+    for _ in 0..WARMUP_ITERATIONS {
+        run(args);
     }
 
-    #[bench]
-    fn translate_absolute_argument(b: &mut Bencher) {
-        let p = env::current_dir()
-            .unwrap()
-            .as_path()
-            .join("src\\main.rs")
-            .as_path()
-            .to_string_lossy()
-            .into_owned();
-        let file_path = p.as_str();
-
-        b.iter(|| {
-            Command::new("wslgit")
-                .args(&["log", "-n1", "--oneline", "--", file_path])
-                .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
-                .output()
-        })
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        run(args);
+        samples.push(start.elapsed());
     }
 
-    #[bench]
-    fn translate_relative_argument(b: &mut Bencher) {
-        let file_path = "src\\main.rs";
+    let total: Duration = samples.iter().sum();
+    let mean = total.as_secs_f64() * 1_000.0 / iterations as f64;
+    let min = samples.iter().min().unwrap().as_secs_f64() * 1_000.0;
+    let max = samples.iter().max().unwrap().as_secs_f64() * 1_000.0;
+    println!(
+        "{}: mean {:.2} ms (min {:.2} ms, max {:.2} ms, n={})",
+        name, mean, min, max, iterations
+    );
+}
 
-        b.iter(|| {
-            Command::new("wslgit")
-                .args(&["log", "-n1", "--oneline", "--", file_path])
-                .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
-                .output()
-        })
+fn benchmark_iterations() -> usize {
+    let mut args = env::args().skip(1);
+    let mut configured_iterations = None;
+    while let Some(argument) = args.next() {
+        match argument.as_str() {
+            "--bench" => {}
+            "--iterations" => {
+                assert!(
+                    configured_iterations.is_none(),
+                    "--iterations may only be supplied once"
+                );
+                configured_iterations = Some(
+                    args.next()
+                        .expect("--iterations requires a positive integer")
+                        .parse::<usize>()
+                        .expect("--iterations requires a positive integer"),
+                );
+            }
+            _ => panic!("unexpected benchmark argument: {}", argument),
+        }
     }
 
-    #[bench]
-    fn translate_output(b: &mut Bencher) {
-        b.iter(|| {
-            Command::new("wslgit")
-                .args(&["rev-parse", "--show-toplevel"])
-                .env("WSLGIT_USE_INTERACTIVE_SHELL", "false")
-                .output()
-        })
-    }
+    let iterations = configured_iterations.unwrap_or(DEFAULT_ITERATIONS);
+    assert!(iterations > 0, "--iterations must be greater than zero");
+    iterations
+}
+
+fn main() {
+    let iterations = benchmark_iterations();
+
+    let absolute_path = env::current_dir()
+        .expect("failed to resolve benchmark directory")
+        .join("src\\main.rs")
+        .to_string_lossy()
+        .into_owned();
+
+    benchmark("no_translation", iterations, &["--version"]);
+    benchmark(
+        "translate_absolute_argument",
+        iterations,
+        &["log", "-n1", "--oneline", "--", &absolute_path],
+    );
+    benchmark(
+        "translate_relative_argument",
+        iterations,
+        &["log", "-n1", "--oneline", "--", "src\\main.rs"],
+    );
+    benchmark(
+        "translate_output",
+        iterations,
+        &["rev-parse", "--show-toplevel"],
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,101 @@ fn translate_path_to_unix(argument: String) -> String {
     std::str::from_utf8(&argument).unwrap().to_string()
 }
 
-fn translate_path_to_win(line: &[u8]) -> Vec<u8> {
+fn translate_unix_path_direct(
+    path: &[u8],
+    wsl_unc_prefix: Option<&[u8]>,
+    windows_drive: Option<u8>,
+) -> Option<Vec<u8>> {
+    if path.starts_with(b"/mnt/")
+        && path.len() >= b"/mnt/c".len()
+        && path[b"/mnt/".len()].is_ascii_alphabetic()
+        && (path.len() == b"/mnt/c".len() || path[b"/mnt/c".len()] == b'/')
+    {
+        let path_drive = path[b"/mnt/".len()].to_ascii_uppercase();
+        if windows_drive.map(|drive| drive.to_ascii_uppercase()) != Some(path_drive) {
+            return None;
+        }
+        let mut translated = Vec::with_capacity(path.len() - b"/mnt/c".len() + 3);
+        translated.push(path_drive);
+        translated.extend_from_slice(b":\\");
+        for byte in path.iter().skip(b"/mnt/c/".len()) {
+            translated.push(if *byte == b'/' { b'\\' } else { *byte });
+        }
+        return Some(translated);
+    }
+
+    let wsl_unc_prefix = wsl_unc_prefix?;
+    let mut translated = Vec::with_capacity(path.len() + wsl_unc_prefix.len());
+    translated.extend_from_slice(wsl_unc_prefix);
+    for byte in path {
+        translated.push(if *byte == b'/' { b'\\' } else { *byte });
+    }
+    Some(translated)
+}
+
+fn translate_path_to_win_direct(
+    line: &[u8],
+    wsl_unc_prefix: Option<&[u8]>,
+    windows_drive: Option<u8>,
+) -> Option<Vec<u8>> {
+    lazy_static! {
+        static ref WSLPATH_RE: Regex =
+            Regex::new(r"(?m)(?-u)(?P<pre>^|[[:space:]])(?P<path>/([^<>:|?'*\n]*/?)*)")
+                .expect("Failed to compile WSLPATH_RE regex");
+    }
+
+    let mut translated = Vec::with_capacity(line.len());
+    let mut previous_end = 0;
+
+    for captures in WSLPATH_RE.captures_iter(line) {
+        let path_match = captures.name("path").unwrap();
+        let mut path = path_match.as_bytes();
+        let remote_suffix = if path.ends_with(b" (fetch)") {
+            path = &path[..path.len() - b" (fetch)".len()];
+            &b" (fetch)"[..]
+        } else if path.ends_with(b" (push)") {
+            path = &path[..path.len() - b" (push)".len()];
+            &b" (push)"[..]
+        } else {
+            &b""[..]
+        };
+
+        translated.extend_from_slice(&line[previous_end..path_match.start()]);
+        translated.extend_from_slice(&translate_unix_path_direct(
+            path,
+            wsl_unc_prefix,
+            windows_drive,
+        )?);
+        translated.extend_from_slice(remote_suffix);
+        previous_end = path_match.end();
+    }
+
+    translated.extend_from_slice(&line[previous_end..]);
+    Some(translated)
+}
+
+fn wsl_path_translation_command(wsl_dist: Option<&str>) -> Command {
+    let mut command = Command::new("wsl");
+    if let Some(wsl_dist) = wsl_dist {
+        command.arg("--distribution").arg(wsl_dist);
+    }
+    command.arg("-e").arg(BASH_EXECUTABLE).arg("-c");
+    command
+}
+
+fn translate_path_to_win(
+    line: &[u8],
+    wsl_unc_prefix: Option<&[u8]>,
+    windows_drive: Option<u8>,
+    wsl_dist: Option<&str>,
+) -> Vec<u8> {
+    if let Some(translated) = translate_path_to_win_direct(line, wsl_unc_prefix, windows_drive) {
+        return translated;
+    }
+    if std::str::from_utf8(line).is_err() {
+        return line.to_vec();
+    }
+
     // Windows can handle both / and \ as path separator so there is no need to convert relative paths.
 
     // An absolute Unix path must:
@@ -145,10 +239,7 @@ fn translate_path_to_win(line: &[u8]) -> Vec<u8> {
         let line = std::str::from_utf8(&line).unwrap();
 
         let echo_cmd = format!("echo -n \"{}\"", line);
-        let output = Command::new("wsl")
-            .arg("-e")
-            .arg(BASH_EXECUTABLE)
-            .arg("-c")
+        let output = wsl_path_translation_command(wsl_dist)
             .arg(&echo_cmd)
             .output()
             .expect("failed to execute echo_cmd");
@@ -354,6 +445,37 @@ fn get_wsl_dist_name(path: &str) -> Option<String> {
     return wsl_dist_name;
 }
 
+fn get_wsl_unc_prefix(path: &str) -> Option<String> {
+    const UNC_SERVER_WSL: &str = "\\\\wsl$\\";
+    const UNC_SERVER_WSL_LOCALHOST: &str = "\\\\wsl.localhost\\";
+
+    let (server, path_without_server) = if let Some(path) = path.strip_prefix(UNC_SERVER_WSL) {
+        (UNC_SERVER_WSL, path)
+    } else {
+        let path = path.strip_prefix(UNC_SERVER_WSL_LOCALHOST)?;
+        (UNC_SERVER_WSL_LOCALHOST, path)
+    };
+
+    let (dist_name, _) = path_without_server.split_once('\\')?;
+    if dist_name.is_empty() {
+        return None;
+    }
+    Some(format!("{}{}", server, dist_name))
+}
+
+fn get_windows_drive_letter(path: &str) -> Option<u8> {
+    let bytes = path.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+    {
+        Some(bytes[0].to_ascii_uppercase())
+    } else {
+        None
+    }
+}
+
 fn enable_logging() -> bool {
     if let Ok(enable_log_flag) = env::var("WSLGIT_ENABLE_LOGGING") {
         if enable_log_flag == "true" || enable_log_flag == "1" {
@@ -414,7 +536,10 @@ fn main() {
     // Assumes that the first element in args is the executable
     let args: Vec<String> = env::args().skip(1).collect();
     let working_directory = get_working_directory(curr_dir, &args);
-    match get_wsl_dist_name(&working_directory) {
+    let wsl_dist = get_wsl_dist_name(&working_directory);
+    let wsl_unc_prefix = get_wsl_unc_prefix(&working_directory);
+    let windows_drive = get_windows_drive_letter(&working_directory);
+    match wsl_dist.as_ref() {
         Some(wsl_dist) => {
             cmd_args.push("--distribution".to_string());
             cmd_args.push(wsl_dist.to_string());
@@ -501,7 +626,12 @@ fn main() {
         let output_bytes = output.stdout;
         let mut stdout = io::stdout();
         stdout
-            .write_all(&translate_path_to_win(&output_bytes))
+            .write_all(&translate_path_to_win(
+                &output_bytes,
+                wsl_unc_prefix.as_deref().map(str::as_bytes),
+                windows_drive,
+                wsl_dist.as_deref(),
+            ))
             .expect("Failed to write git output");
         stdout.flush().expect("Failed to flush output");
     } else {
@@ -733,6 +863,76 @@ mod tests {
     }
 
     #[test]
+    fn selected_distribution_translates_output_without_wsl() {
+        let output = b"first /home/\xff/repo\nsecond /tmp/other (fetch)\nraw \xfe\n";
+
+        assert_eq!(
+            translate_path_to_win_direct(
+                output,
+                Some(b"\\\\wsl.localhost\\Test-Distro"),
+                None
+            ),
+            Some(
+                b"first \\\\wsl.localhost\\Test-Distro\\home\\\xff\\repo\nsecond \\\\wsl.localhost\\Test-Distro\\tmp\\other (fetch)\nraw \xfe\n"
+                    .to_vec()
+            )
+        );
+    }
+
+    #[test]
+    fn mounted_drive_translates_output_without_wsl() {
+        assert_eq!(
+            translate_path_to_win_direct(b"/mnt/c/work/repo\n", None, Some(b'C')),
+            Some(b"C:\\work\\repo\n".to_vec())
+        );
+    }
+
+    #[test]
+    fn unproven_mounted_drive_uses_fallback() {
+        assert_eq!(
+            translate_path_to_win_direct(b"/mnt/z/work/repo\n", None, None),
+            None
+        );
+    }
+
+    #[test]
+    fn output_translation_uses_direct_path_for_unc_worktree() {
+        assert_eq!(
+            translate_path_to_win(
+                b"/home/repo\n",
+                Some(b"\\\\wsl.localhost\\No-Such-Distro"),
+                None,
+                Some("No-Such-Distro")
+            ),
+            b"\\\\wsl.localhost\\No-Such-Distro\\home\\repo\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn unsupported_non_utf8_output_is_preserved() {
+        let output = b"/home/\xff/repo\n";
+
+        assert_eq!(
+            translate_path_to_win(output, None, None, None),
+            output.to_vec()
+        );
+    }
+
+    #[test]
+    fn path_translation_fallback_uses_selected_distribution() {
+        let command = wsl_path_translation_command(Some("Test-Distro"));
+        let args: Vec<_> = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            args,
+            vec!["--distribution", "Test-Distro", "-e", "/bin/bash", "-c"]
+        );
+    }
+
+    #[test]
     fn unix_to_win_path_trans() {
         let check_wslpath = Command::new("wsl")
             .arg("-e")
@@ -740,7 +940,7 @@ mod tests {
             .arg("-c")
             .arg("wslpath C:\\")
             .output();
-        let prefix_bytes = translate_path_to_win(b"/");
+        let prefix_bytes = translate_path_to_win(b"/", None, None, None);
         let prefix = std::str::from_utf8(&prefix_bytes).unwrap();
         if check_wslpath.is_err()
             || !check_wslpath.expect("bash output").status.success()
@@ -763,18 +963,33 @@ mod tests {
             .output()
             .expect("creating tmp test file");
         assert_eq!(
-            std::str::from_utf8(&translate_path_to_win(b"/tmp/wslgit test file")).unwrap(),
+            std::str::from_utf8(&translate_path_to_win(
+                b"/tmp/wslgit test file",
+                None,
+                None,
+                None,
+            ))
+            .unwrap(),
             format!("{}tmp\\wslgit test file", prefix)
         );
         assert_eq!(
             std::str::from_utf8(&translate_path_to_win(
-                b"origin  /tmp/wslgit test file (fetch)"
+                b"origin  /tmp/wslgit test file (fetch)",
+                None,
+                None,
+                None
             ))
             .unwrap(),
             format!("origin  {}tmp\\wslgit test file (fetch)", prefix)
         );
         assert_eq!(
-            std::str::from_utf8(&translate_path_to_win(b"mirror  /tmp/wslgit test file (fetch)\nmirror  /tmp/wslgit test file (push)\n")).unwrap(),
+            std::str::from_utf8(&translate_path_to_win(
+                b"mirror  /tmp/wslgit test file (fetch)\nmirror  /tmp/wslgit test file (push)\n",
+                None,
+                None,
+                None,
+            ))
+            .unwrap(),
             format!("mirror  {0}tmp\\wslgit test file (fetch)\nmirror  {0}tmp\\wslgit test file (push)\n", prefix)
         );
         Command::new("wsl")
@@ -1084,6 +1299,29 @@ mod tests {
             None
         );
         assert_eq!(get_wsl_dist_name(&r"C:\a\b\c".to_string()), None);
+    }
+
+    #[test]
+    fn wsl_unc_prefix_preserves_server_style() {
+        assert_eq!(
+            get_wsl_unc_prefix(r"\\wsl$\dist-name\a\b\c"),
+            Some(r"\\wsl$\dist-name".to_string())
+        );
+        assert_eq!(
+            get_wsl_unc_prefix(r"\\wsl.localhost\dist-name\a\b\c"),
+            Some(r"\\wsl.localhost\dist-name".to_string())
+        );
+        assert_eq!(get_wsl_unc_prefix(r"C:\a\b\c"), None);
+    }
+
+    #[test]
+    fn windows_drive_letter_comes_from_working_directory() {
+        assert_eq!(get_windows_drive_letter(r"C:\work\repo"), Some(b'C'));
+        assert_eq!(get_windows_drive_letter(r"d:/work/repo"), Some(b'D'));
+        assert_eq!(
+            get_windows_drive_letter(r"\\wsl.localhost\Ubuntu\home\repo"),
+            None
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -791,6 +791,14 @@ mod tests {
         unsafe {
             DOUBLE_DASH_FOUND = false;
         }
+        let checkout_name = env::current_dir()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let relative_windows_path = format!("..\\{}\\src\\main.rs", checkout_name);
+        let relative_unix_path = format!("../{}/src/main.rs", checkout_name);
 
         assert_eq!(
             translate_path_to_unix("src\\main.rs".to_string()),
@@ -809,17 +817,17 @@ mod tests {
             "./src/main.rs"
         );
         assert_eq!(
-            translate_path_to_unix("..\\wslgit\\src\\main.rs".to_string()),
-            "../wslgit/src/main.rs"
+            translate_path_to_unix(relative_windows_path.clone()),
+            relative_unix_path
         );
         assert_eq!(
-            translate_path_to_unix("../wslgit/src/main.rs".to_string()),
-            "../wslgit/src/main.rs"
+            translate_path_to_unix(relative_unix_path.clone()),
+            relative_unix_path
         );
 
         assert_eq!(
-            translate_path_to_unix("prefix:..\\wslgit\\src\\main.rs:postfix".to_string()),
-            "prefix:../wslgit/src/main.rs:postfix"
+            translate_path_to_unix(format!("prefix:{}:postfix", relative_windows_path)),
+            format!("prefix:{}:postfix", relative_unix_path)
         );
 
         assert_eq!(
@@ -828,8 +836,8 @@ mod tests {
         );
 
         assert_eq!(
-            translate_path_to_unix("\"prefix:..\\wslgit\\src\\main.rs\"".to_string()),
-            "\"prefix:../wslgit/src/main.rs\""
+            translate_path_to_unix(format!("\"prefix:{}\"", relative_windows_path)),
+            format!("\"prefix:{}\"", relative_unix_path)
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -267,12 +267,21 @@ mod integration {
 
     #[test]
     fn shell_environment_variable() {
+        let expected_shell = Command::new("wsl")
+            .args(["-e", "/bin/bash", "-c", "printenv SHELL"])
+            .output()
+            .expect("failed to read the WSL shell environment");
+        assert!(expected_shell.status.success());
+        let expected_shell = String::from_utf8(expected_shell.stdout)
+            .expect("WSL returned a non-UTF-8 shell path")
+            .trim_end()
+            .to_string();
+
         Command::new(cargo_bin!(env!("CARGO_PKG_NAME")))
-            // Use pretty format to call 'printenv SHELL'
             .args(&["log", "-1", "--pretty=format:$(printenv SHELL)"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("/bin/bash"));
+            .stdout(expected_shell);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- translate common WSL output paths without launching a second WSL process
- preserve the selected-distribution fallback for ambiguous mappings
- preserve unsupported non-UTF-8 output unchanged
- replace the nightly-only benchmark with a stable, self-checking harness
- remove checkout-name and login-shell assumptions from tests

## Problem

Commands whose output contains absolute paths currently launch WSL again to run
`wslpath`. That second process is a large part of the wrapper's latency. A direct
conversion is only safe when the current Windows working directory proves the
distribution or drive mapping.

## Implementation

The wrapper now derives either the active WSL UNC prefix or the Windows drive
from the working directory. It uses that evidence to translate matching output
in process. Unknown mount drives and other ambiguous paths retain the existing
`wslpath` fallback, including the selected distribution.

The benchmark now runs on stable Rust, resolves the exact Cargo-built binary,
warms up each case, rejects failed or empty runs, and supports
`--iterations <N>`.

## Benchmark

In a representative 10-iteration run of the same output-translation case, the
mean fell from 428.02 ms to 333.66 ms: 94.36 ms, or 22.0%. End-to-end timings
remain dominated by Windows/WSL process startup and vary between runs.

## Verification

- `cargo test --target x86_64-pc-windows-gnu -- --test-threads=1`
  - 26 unit tests passed
  - 14 integration tests passed
- `cargo bench --target x86_64-pc-windows-gnu --bench benchmark -- --iterations 1`
- `cargo build --release --target x86_64-pc-windows-gnu`
- `cargo fmt --all -- --check`
- `cargo clippy --target x86_64-pc-windows-gnu --all-targets`
- `git diff --check`
